### PR TITLE
Add filtering via JSON tree structure

### DIFF
--- a/entwine/reader/CMakeLists.txt
+++ b/entwine/reader/CMakeLists.txt
@@ -5,6 +5,8 @@ set(
     SOURCES
     "${BASE}/cache.cpp"
     "${BASE}/chunk-reader.cpp"
+    "${BASE}/comparison.cpp"
+    "${BASE}/logic-gate.cpp"
     "${BASE}/query.cpp"
     "${BASE}/reader.cpp"
 )
@@ -13,6 +15,10 @@ set(
     HEADERS
     "${BASE}/cache.hpp"
     "${BASE}/chunk-reader.hpp"
+    "${BASE}/comparison.hpp"
+    "${BASE}/filter.hpp"
+    "${BASE}/filterable.hpp"
+    "${BASE}/logic-gate.hpp"
     "${BASE}/query.hpp"
     "${BASE}/reader.hpp"
 )

--- a/entwine/reader/cache.cpp
+++ b/entwine/reader/cache.cpp
@@ -126,10 +126,13 @@ void Cache::release(const Block& block)
         }
     }
 
-    std::cout <<
-        "\tActive size: " << m_activeCount <<
-        "\tIdle size: " << m_inactiveList.size() <<
-        "\tThis query: " << block.chunkMap().size() << std::endl;
+    if (m_activeCount)
+    {
+        std::cout <<
+            "\tActive size: " << m_activeCount <<
+            "\tIdle size: " << m_inactiveList.size() <<
+            "\tThis query: " << block.chunkMap().size() << std::endl;
+    }
 
     if (notify)
     {

--- a/entwine/reader/comparison.cpp
+++ b/entwine/reader/comparison.cpp
@@ -1,0 +1,240 @@
+/******************************************************************************
+* Copyright (c) 2016, Connor Manning (connor@hobu.co)
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#include <entwine/reader/comparison.hpp>
+
+#include <json/json.h>
+
+#include <entwine/tree/manifest.hpp>
+#include <entwine/types/metadata.hpp>
+#include <entwine/types/schema.hpp>
+#include <entwine/util/json.hpp>
+
+namespace entwine
+{
+
+namespace
+{
+
+double extractComparisonValue(
+        const Metadata& metadata,
+        const std::string& dimensionName,
+        const Json::Value& val)
+{
+    double d(0);
+
+    if (dimensionName == "Path")
+    {
+        if (!val.isString())
+        {
+            throw std::runtime_error(
+                    "Invalid path - must be string: " + val.toStyledString());
+        }
+
+        // If this dimension is a path, we need to convert the path
+        // string to an Origin.
+        const std::string path(val.asString());
+        const Origin origin(metadata.manifest().find(path));
+        if (origin == invalidOrigin)
+        {
+            throw std::runtime_error("Could not find path: " + path);
+        }
+
+        d = origin;
+    }
+    else
+    {
+        if (!val.isConvertibleTo(Json::ValueType::realValue))
+        {
+            throw std::runtime_error(
+                    "Invalid comparison value: " + val.toStyledString());
+        }
+
+        if (dimensionName == "Origin")
+        {
+            const Origin origin(val.asUInt64());
+            if (origin > metadata.manifest().size())
+            {
+                throw std::runtime_error(
+                        "Could not find origin: " + std::to_string(origin));
+            }
+        }
+
+        d = val.asDouble();
+    }
+
+    return d;
+}
+
+std::unique_ptr<Bounds> maybeExtractBounds(
+        const Metadata& metadata,
+        const std::string& dimensionName,
+        double val)
+{
+    std::unique_ptr<Bounds> b;
+
+    if (dimensionName == "Path" || dimensionName == "Origin")
+    {
+        const Origin origin(val);
+        const auto& fileInfo(metadata.manifest().get(origin));
+
+        if (const Bounds* bounds = fileInfo.bounds())
+        {
+            b = makeUnique<Bounds>(*bounds);
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Could not extract bounds for origin: " +
+                std::to_string(origin));
+        }
+    }
+
+    return b;
+}
+
+}
+
+std::unique_ptr<Comparison> Comparison::create(
+        const Metadata& metadata,
+        std::string dimensionName,
+        const Json::Value& val)
+{
+    auto op(ComparisonOperator::create(metadata, dimensionName, val));
+    if (dimensionName == "Path") dimensionName = "Origin";
+
+    const auto id(metadata.schema().getId(dimensionName));
+    if (id == pdal::Dimension::Id::Unknown)
+    {
+        throw std::runtime_error("Unknown dimension: " + dimensionName);
+    }
+
+    return makeUnique<Comparison>(id, dimensionName, std::move(op));
+}
+
+std::unique_ptr<ComparisonOperator> ComparisonOperator::create(
+        const Metadata& metadata,
+        const std::string& dimensionName,
+        const Json::Value& json)
+{
+    if (json.isObject())
+    {
+        if (json.size() != 1)
+        {
+            throw std::runtime_error(
+                    "Invalid comparison object: " + json.toStyledString());
+        }
+
+        const auto& key(json.getMemberNames().at(0));
+        const ComparisonType co(toComparisonType(key));
+        const auto& val(json[key]);
+
+        if (isSingle(co))
+        {
+            const double d(
+                    extractComparisonValue(
+                        metadata,
+                        dimensionName,
+                        val));
+
+            auto b(maybeExtractBounds(metadata, dimensionName, d));
+
+            if (dimensionName == "Path" || dimensionName == "Origin")
+            {
+                if (co != ComparisonType::eq)
+                {
+                    throw std::runtime_error(
+                            toString(co) + " not supported for dimension: " +
+                            dimensionName);
+                }
+            }
+
+            switch (co)
+            {
+            case ComparisonType::eq:
+                return createSingle(co, std::equal_to<double>(), d, b.get());
+                break;
+            case ComparisonType::gt:
+                return createSingle(co, std::greater<double>(), d);
+                break;
+            case ComparisonType::gte:
+                return createSingle(co, std::greater_equal<double>(), d);
+                break;
+            case ComparisonType::lt:
+                return createSingle(co, std::less<double>(), d);
+                break;
+            case ComparisonType::lte:
+                return createSingle(co, std::less_equal<double>(), d);
+                break;
+            case ComparisonType::ne:
+                return createSingle(
+                        co, std::not_equal_to<double>(), d, b.get());
+                break;
+            default:
+                throw std::runtime_error("Invalid single comparison operator");
+            }
+        }
+        else
+        {
+            if (!val.isArray())
+            {
+                throw std::runtime_error("Invalid comparison list");
+            }
+
+            std::vector<double> vals;
+            std::vector<Bounds> boundsList;
+
+            for (const Json::Value& single : val)
+            {
+                const double d(
+                        extractComparisonValue(
+                            metadata,
+                            dimensionName,
+                            single));
+
+                vals.push_back(d);
+
+                if (auto b = maybeExtractBounds(metadata, dimensionName, d))
+                {
+                    boundsList.push_back(*b);
+                }
+            }
+
+            if (dimensionName == "Path" || dimensionName == "Origin")
+            {
+                if (co != ComparisonType::in)
+                {
+                    throw std::runtime_error(
+                            toString(co) + " not supported for dimension: " +
+                            dimensionName);
+                }
+            }
+
+            if (co == ComparisonType::in)
+            {
+                return makeUnique<ComparisonAny>(vals, boundsList);
+            }
+            else if (co == ComparisonType::nin)
+            {
+                return makeUnique<ComparisonNone>(vals, boundsList);
+            }
+            else throw std::runtime_error("Invalid multi comparison operator");
+        }
+    }
+    else
+    {
+        Json::Value next;
+        next["$eq"] = json;
+        return create(metadata, dimensionName, next);
+    }
+}
+
+} // namespace entwine
+

--- a/entwine/reader/comparison.hpp
+++ b/entwine/reader/comparison.hpp
@@ -1,0 +1,295 @@
+/******************************************************************************
+* Copyright (c) 2016, Connor Manning (connor@hobu.co)
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <vector>
+
+#include <entwine/reader/filterable.hpp>
+#include <entwine/types/bounds.hpp>
+#include <entwine/types/defs.hpp>
+#include <entwine/util/unique.hpp>
+
+namespace Json { class Value; }
+
+namespace entwine
+{
+
+class Metadata;
+
+enum class ComparisonType
+{
+    eq,
+    gt,
+    gte,
+    lt,
+    lte,
+    ne,
+    in,
+    nin
+};
+
+inline bool isComparisonType(const std::string& s)
+{
+    return s.size() && s.front() == '$' && (
+            s == "$eq" ||
+            s == "$gt" ||
+            s == "$gte" ||
+            s == "$lt" ||
+            s == "$lte" ||
+            s == "$ne" ||
+            s == "$in" ||
+            s == "$nin");
+}
+
+inline ComparisonType toComparisonType(const std::string& s)
+{
+    if (s == "$eq")         return ComparisonType::eq;
+    else if (s == "$gt")    return ComparisonType::gt;
+    else if (s == "$gte")   return ComparisonType::gte;
+    else if (s == "$lt")    return ComparisonType::lt;
+    else if (s == "$lte")   return ComparisonType::lte;
+    else if (s == "$ne")    return ComparisonType::ne;
+    else if (s == "$in")    return ComparisonType::in;
+    else if (s == "$nin")   return ComparisonType::nin;
+    else throw std::runtime_error("Invalid comparison type: " + s);
+}
+
+inline std::string toString(ComparisonType c)
+{
+    switch (c)
+    {
+        case ComparisonType::eq: return "$eq";
+        case ComparisonType::gt: return "$gt";
+        case ComparisonType::gte: return "$gte";
+        case ComparisonType::lt: return "$lt";
+        case ComparisonType::lte: return "$lte";
+        case ComparisonType::ne: return "$ne";
+        case ComparisonType::in: return "$in";
+        case ComparisonType::nin: return "$nin";
+    }
+}
+
+inline bool isSingle(ComparisonType co)
+{
+    return co != ComparisonType::in && co != ComparisonType::nin;
+}
+
+inline bool isMultiple(ComparisonType co)
+{
+    return !isSingle(co);
+}
+
+class ComparisonOperator
+{
+public:
+    ComparisonOperator(ComparisonType type) : m_type(type) { }
+
+    virtual ~ComparisonOperator() { }
+
+    // Accepts a JSON value of the form:
+    // { "$<op>": <val> }       // E.g. { "$eq": 42 }
+    //
+    // or the special case for the "$eq" operator:
+    //      <val>               // Equivalent to the above.
+    //
+    //
+    // Returns a pointer to a functor that performs the requested comparison.
+    static std::unique_ptr<ComparisonOperator> create(
+            const Metadata& metadata,
+            const std::string& dimensionName,
+            const Json::Value& json);
+
+    virtual bool operator()(double in) const = 0;
+    virtual bool operator()(const Bounds& bounds) const { return true; }
+    virtual void log(const std::string& pre) const = 0;
+
+    virtual std::vector<Origin> origins() const
+    {
+        return std::vector<Origin>();
+    }
+
+    ComparisonType type() const { return m_type; }
+
+protected:
+    ComparisonType m_type;
+};
+
+template<typename Op>
+class ComparisonSingle : public ComparisonOperator
+{
+public:
+    ComparisonSingle(ComparisonType type, Op op, double val, const Bounds* b)
+        : ComparisonOperator(type)
+        , m_op(op)
+        , m_val(val)
+        , m_bounds(maybeClone(b))
+    { }
+
+    virtual bool operator()(double in) const override
+    {
+        return m_op(in, m_val);
+    }
+
+    virtual bool operator()(const Bounds& bounds) const override
+    {
+        return !m_bounds || m_bounds->overlaps(bounds, true);
+    }
+
+    virtual void log(const std::string& pre) const override
+    {
+        std::cout << pre << toString(m_type) << " " << m_val;
+        if (m_bounds) std::cout << " " << *m_bounds;
+        std::cout << std::endl;
+    }
+
+    virtual std::vector<Origin> origins() const override
+    {
+        std::vector<Origin> o;
+        o.push_back(m_val);
+        return o;
+    }
+
+protected:
+    Op m_op;
+    double m_val;
+    std::unique_ptr<Bounds> m_bounds;
+};
+
+class ComparisonMulti : public ComparisonOperator
+{
+public:
+    ComparisonMulti(
+            ComparisonType type,
+            const std::vector<double>& vals,
+            const std::vector<Bounds>& boundsList)
+        : ComparisonOperator(type)
+        , m_vals(vals)
+        , m_boundsList(boundsList)
+    { }
+
+    virtual void log(const std::string& pre) const override
+    {
+        std::cout << pre << toString(m_type) << " ";
+        for (const double d : m_vals) std::cout << d << " ";
+        std::cout << std::endl;
+
+        for (const auto& b : m_boundsList)
+        {
+            std::cout << pre << "  " << b << std::endl;
+        }
+    }
+
+protected:
+    std::vector<double> m_vals;
+    std::vector<Bounds> m_boundsList;
+};
+
+class ComparisonAny : public ComparisonMulti
+{
+public:
+    ComparisonAny(
+            const std::vector<double>& vals,
+            const std::vector<Bounds>& boundsList)
+        : ComparisonMulti(ComparisonType::in, vals, boundsList)
+    { }
+
+    virtual bool operator()(double in) const override
+    {
+        return std::any_of(m_vals.begin(), m_vals.end(), [in](double val)
+        {
+            return in == val;
+        });
+    }
+
+    virtual bool operator()(const Bounds& bounds) const override
+    {
+        if (m_boundsList.empty()) return true;
+        else
+        {
+            for (const auto& b : m_boundsList)
+            {
+                if (b.overlaps(bounds, true)) return true;
+            }
+
+            return false;
+        }
+    }
+};
+
+class ComparisonNone : public ComparisonMulti
+{
+public:
+    ComparisonNone(
+            const std::vector<double>& vals,
+            const std::vector<Bounds>& boundsList)
+        : ComparisonMulti(ComparisonType::nin, vals, boundsList)
+    { }
+
+    virtual bool operator()(double in) const override
+    {
+        return std::none_of(m_vals.begin(), m_vals.end(), [in](double val)
+        {
+            return in == val;
+        });
+    }
+};
+
+template<typename O>
+inline std::unique_ptr<ComparisonSingle<O>> createSingle(
+        ComparisonType type,
+        O op,
+        double d,
+        const Bounds* b = nullptr)
+{
+    return makeUnique<ComparisonSingle<O>>(type, op, d, b);
+}
+
+class Comparison : public Filterable
+{
+public:
+    Comparison(
+            pdal::Dimension::Id dim,
+            const std::string& dimensionName,
+            std::unique_ptr<ComparisonOperator> op)
+        : m_dim(dim)
+        , m_name(dimensionName)
+        , m_op(std::move(op))
+    { }
+
+    static std::unique_ptr<Comparison> create(
+            const Metadata& metadata,
+            std::string dimName,
+            const Json::Value& val);
+
+    bool check(const pdal::PointRef& pointRef) const override
+    {
+        return (*m_op)(pointRef.getFieldAs<double>(m_dim));
+    }
+
+    bool check(const Bounds& bounds) const override
+    {
+        return (*m_op)(bounds);
+    }
+
+    virtual void log(const std::string& pre) const override
+    {
+        std::cout << pre << m_name << " ";
+        m_op->log("");
+    }
+
+protected:
+    pdal::Dimension::Id m_dim;
+    std::string m_name;
+    std::unique_ptr<ComparisonOperator> m_op;
+};
+
+} // namespace entwine
+

--- a/entwine/reader/filter.hpp
+++ b/entwine/reader/filter.hpp
@@ -1,0 +1,119 @@
+/******************************************************************************
+* Copyright (c) 2016, Connor Manning (connor@hobu.co)
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include <json/json.h>
+
+#include <entwine/reader/comparison.hpp>
+#include <entwine/reader/logic-gate.hpp>
+#include <entwine/types/metadata.hpp>
+
+namespace entwine
+{
+
+class Filter
+{
+public:
+    Filter(
+            const Metadata& metadata,
+            const Bounds& queryBounds,
+            const Json::Value& json)
+        : m_metadata(metadata)
+        , m_queryBounds(queryBounds)
+        , m_root()
+    {
+        if (json.isObject()) build(m_root, json);
+        m_root.log("");
+    }
+
+    bool check(const pdal::PointRef& pointRef) const
+    {
+        return m_root.check(pointRef);
+    }
+
+    bool check(const Bounds& bounds) const
+    {
+        return m_queryBounds.overlaps(bounds) && m_root.check(bounds);
+    }
+
+private:
+    void build(LogicGate& gate, const Json::Value& json)
+    {
+        if (json.isObject())
+        {
+            LogicGate* active(&gate);
+
+            std::unique_ptr<LogicGate> outer;
+
+            if (json.size() > 1)
+            {
+                outer = LogicGate::create(LogicalOperator::lAnd);
+                active = outer.get();
+            }
+
+            for (const std::string& key : json.getMemberNames())
+            {
+                const Json::Value& val(json[key]);
+
+                if (isLogicalOperator(key))
+                {
+                    auto inner(LogicGate::create(key));
+                    build(*inner, val);
+                    active->push(std::move(inner));
+                }
+                else if (!val.isObject() || val.size() == 1)
+                {
+                    // key is the name of a dimension, val is either a number or
+                    // an comparison query object.
+                    active->push(Comparison::create(m_metadata, key, val));
+                }
+                else
+                {
+                    // key is the name of a dimension, val is an object of
+                    // multiple comparison key/val pairs, for example:
+                    //
+                    // key: "Red"
+                    // val: { "$gt": 100, "$lt": 200 }
+                    //
+                    // There cannot be any further nested logical operators
+                    // within val, since we've already selected a dimension.
+                    //
+                    for (const std::string& innerKey : val.getMemberNames())
+                    {
+                        Json::Value next;
+                        next[innerKey] = val[innerKey];
+                        active->push(Comparison::create(m_metadata, key, next));
+                    }
+                }
+            }
+
+            if (outer) gate.push(std::move(outer));
+        }
+        else if (json.isArray())
+        {
+            for (const Json::Value& val : json) build(gate, val);
+        }
+        else
+        {
+            throw std::runtime_error(
+                    "Unexpected filter type: " + json.toStyledString());
+        }
+    }
+
+    const Metadata& m_metadata;
+    const Bounds m_queryBounds;
+    LogicalAnd m_root;
+};
+
+} // namespace entwine
+

--- a/entwine/reader/filterable.hpp
+++ b/entwine/reader/filterable.hpp
@@ -1,0 +1,32 @@
+/******************************************************************************
+* Copyright (c) 2016, Connor Manning (connor@hobu.co)
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include <pdal/PointRef.hpp>
+
+#include <entwine/types/bounds.hpp>
+
+namespace entwine
+{
+
+class Filterable
+{
+public:
+    virtual bool check(const pdal::PointRef& pointRef) const = 0;
+    virtual bool check(const Bounds& bounds) const { return true; }
+    virtual void log(const std::string& pre) const = 0;
+};
+
+} // namespace entwine
+

--- a/entwine/reader/logic-gate.cpp
+++ b/entwine/reader/logic-gate.cpp
@@ -1,0 +1,27 @@
+/******************************************************************************
+* Copyright (c) 2016, Connor Manning (connor@hobu.co)
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#include <entwine/reader/logic-gate.hpp>
+
+#include <entwine/util/unique.hpp>
+
+namespace entwine
+{
+
+std::unique_ptr<LogicGate> LogicGate::create(const LogicalOperator type)
+{
+    if (type == LogicalOperator::lAnd) return makeUnique<LogicalAnd>();
+    else if (type == LogicalOperator::lOr) return makeUnique<LogicalOr>();
+    else if (type == LogicalOperator::lNor) return makeUnique<LogicalNor>();
+    else throw std::runtime_error("Invalid logic gate type");
+}
+
+} // namespace entwine
+

--- a/entwine/reader/logic-gate.hpp
+++ b/entwine/reader/logic-gate.hpp
@@ -1,0 +1,141 @@
+/******************************************************************************
+* Copyright (c) 2016, Connor Manning (connor@hobu.co)
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <entwine/reader/filterable.hpp>
+
+namespace entwine
+{
+
+enum class LogicalOperator
+{
+    lAnd,
+    lOr,
+    lNor
+};
+
+inline bool isLogicalOperator(const std::string& s)
+{
+    return s == "$and" || s == "$or" || s == "$nor";
+}
+
+inline LogicalOperator toLogicalOperator(const std::string& s)
+{
+    if (s == "$and")        return LogicalOperator::lAnd;
+    else if (s == "$or")    return LogicalOperator::lOr;
+    else if (s == "$nor")   return LogicalOperator::lNor;
+    else throw std::runtime_error("Invalid logical operator: " + s);
+}
+
+class LogicGate : public Filterable
+{
+public:
+    virtual ~LogicGate() { }
+
+    static std::unique_ptr<LogicGate> create(const std::string& s)
+    {
+        return create(toLogicalOperator(s));
+    }
+
+    static std::unique_ptr<LogicGate> create(LogicalOperator type);
+
+    void push(std::unique_ptr<Filterable> f)
+    {
+        m_filters.push_back(std::move(f));
+    }
+
+protected:
+    std::vector<std::unique_ptr<Filterable>> m_filters;
+};
+
+class LogicalAnd : public LogicGate
+{
+public:
+    virtual bool check(const pdal::PointRef& pointRef) const override
+    {
+        for (const auto& f : m_filters)
+        {
+            if (!f->check(pointRef)) return false;
+        }
+
+        return true;
+    }
+
+    virtual bool check(const Bounds& bounds) const override
+    {
+        for (const auto& f : m_filters)
+        {
+            if (!f->check(bounds)) return false;
+        }
+
+        return true;
+    }
+
+    virtual void log(const std::string& pre) const override
+    {
+        std::cout << pre << "AND" << std::endl;
+        for (const auto& c : m_filters) c->log(pre + "  ");
+    }
+};
+
+class LogicalOr : public LogicGate
+{
+public:
+    virtual bool check(const pdal::PointRef& pointRef) const override
+    {
+        for (const auto& f : m_filters)
+        {
+            if (f->check(pointRef)) return true;
+        }
+
+        return false;
+    }
+
+    virtual bool check(const Bounds& bounds) const override
+    {
+        for (const auto& f : m_filters)
+        {
+            if (f->check(bounds)) return true;
+        }
+
+        return false;
+    }
+
+    virtual void log(const std::string& pre) const override
+    {
+        std::cout << pre << "OR" << std::endl;
+        for (const auto& c : m_filters) c->log(pre + "  ");
+    }
+};
+
+class LogicalNor : public LogicalOr
+{
+public:
+    using LogicalOr::check;
+    virtual bool check(const pdal::PointRef& pointRef) const override
+    {
+        return !LogicalOr::check(pointRef);
+    }
+
+    virtual bool check(const Bounds& bounds) const override
+    {
+        return !LogicalOr::check(bounds);
+    }
+
+    virtual void log(const std::string& pre) const override
+    {
+        std::cout << pre << "NOR" << std::endl;
+        for (const auto& c : m_filters) c->log(pre + "  ");
+    }
+};
+
+} // namespace entwine
+

--- a/entwine/reader/query.cpp
+++ b/entwine/reader/query.cpp
@@ -10,6 +10,7 @@
 
 #include <entwine/reader/query.hpp>
 
+#include <algorithm>
 #include <iterator>
 
 #include <entwine/reader/cache.hpp>
@@ -32,6 +33,7 @@ namespace
 Query::Query(
         const Reader& reader,
         const Schema& schema,
+        const Json::Value& filter,
         Cache& cache,
         const Bounds& queryBounds,
         const std::size_t depthBegin,
@@ -55,17 +57,19 @@ Query::Query(
     , m_offset(offset)
     , m_table(m_reader.metadata().schema())
     , m_pointRef(m_table, 0)
+    , m_filter(m_reader.metadata(), m_queryBounds, filter)
 {
     if (!m_depthEnd || m_depthEnd > m_structure.coldDepthBegin())
     {
         QueryChunkState chunkState(m_structure, m_reader.metadata().bounds());
         getFetches(chunkState);
+        std::cout << "Fetches: " << m_chunks.size() << std::endl;
     }
 }
 
 void Query::getFetches(const QueryChunkState& chunkState)
 {
-    if (!m_queryBounds.overlaps(chunkState.bounds(), true)) return;
+    if (!m_filter.check(chunkState.bounds())) return;
 
     if (
             chunkState.depth() >= m_depthBegin &&
@@ -77,6 +81,12 @@ void Query::getFetches(const QueryChunkState& chunkState)
                 chunkState.chunkId(),
                 chunkState.pointsPerChunk(),
                 chunkState.depth());
+    }
+    else if (
+            chunkState.depth() >= m_structure.coldDepthBegin() &&
+            !m_reader.exists(chunkState.chunkId()))
+    {
+        return;
     }
 
     if (chunkState.depth() + 1 < m_depthEnd)
@@ -125,7 +135,7 @@ bool Query::next(std::vector<char>& buffer)
 
 void Query::getBase(std::vector<char>& buffer, const PointState& pointState)
 {
-    if (!m_queryBounds.overlaps(pointState.bounds(), true)) return;
+    if (!m_filter.check(pointState.bounds())) return;
 
     if (pointState.depth() >= m_structure.baseDepthBegin())
     {
@@ -202,10 +212,13 @@ bool Query::processPoint(std::vector<char>& buffer, const PointInfo& info)
 {
     if (m_queryBounds.contains(info.point()))
     {
+        m_table.setPoint(info.data());
+
+        if (!m_filter.check(m_pointRef)) return false;
+
         buffer.resize(buffer.size() + m_outSchema.pointSize(), 0);
         char* pos(buffer.data() + buffer.size() - m_outSchema.pointSize());
 
-        m_table.setPoint(info.data());
         bool isX(false), isY(false), isZ(false);
 
         for (const auto& dim : m_outSchema.dims())

--- a/entwine/reader/query.hpp
+++ b/entwine/reader/query.hpp
@@ -15,6 +15,8 @@
 #include <deque>
 
 #include <entwine/reader/cache.hpp>
+#include <entwine/reader/comparison.hpp>
+#include <entwine/reader/filter.hpp>
 #include <entwine/reader/reader.hpp>
 #include <entwine/types/dir.hpp>
 #include <entwine/types/point.hpp>
@@ -95,6 +97,7 @@ public:
     Query(
             const Reader& reader,
             const Schema& schema,
+            const Json::Value& filter,
             Cache& cache,
             const Bounds& queryBounds,
             std::size_t depthBegin,
@@ -128,7 +131,7 @@ protected:
     const Structure& m_structure;
     Cache& m_cache;
 
-    const Bounds m_queryBounds;
+    Bounds m_queryBounds;
     const std::size_t m_depthBegin;
     const std::size_t m_depthEnd;
 
@@ -147,6 +150,8 @@ protected:
 
     BinaryPointTable m_table;
     pdal::PointRef m_pointRef;
+
+    Filter m_filter;
 };
 
 } // namespace entwine

--- a/entwine/reader/reader.cpp
+++ b/entwine/reader/reader.cpp
@@ -107,16 +107,18 @@ Json::Value Reader::hierarchy(
 
 std::unique_ptr<Query> Reader::query(
         const Schema& schema,
+        const Json::Value& filter,
         const std::size_t depthBegin,
         const std::size_t depthEnd,
         const double scale,
         const Point offset)
 {
-    return query(schema, bounds(), depthBegin, depthEnd, scale, offset);
+    return query(schema, filter, bounds(), depthBegin, depthEnd, scale, offset);
 }
 
 std::unique_ptr<Query> Reader::query(
         const Schema& schema,
+        const Json::Value& filter,
         const Bounds& queryBounds,
         const std::size_t depthBegin,
         const std::size_t depthEnd,
@@ -145,6 +147,7 @@ std::unique_ptr<Query> Reader::query(
             new Query(
                 *this,
                 schema,
+                filter,
                 m_cache,
                 queryCube,
                 depthBegin,

--- a/entwine/reader/reader.hpp
+++ b/entwine/reader/reader.hpp
@@ -55,6 +55,7 @@ public:
 
     std::unique_ptr<Query> query(
             const Schema& schema,
+            const Json::Value& filter,
             std::size_t depthBegin,
             std::size_t depthEnd,
             double scale = 0.0,
@@ -62,6 +63,7 @@ public:
 
     std::unique_ptr<Query> query(
             const Schema& schema,
+            const Json::Value& filter,
             const Bounds& qbox,
             std::size_t depthBegin,
             std::size_t depthEnd,

--- a/entwine/tree/hierarchy.cpp
+++ b/entwine/tree/hierarchy.cpp
@@ -401,8 +401,6 @@ void Hierarchy::accumulate(
                 accumulate(*nextJson, ids, query, nextState, curlag, inc);
             }
         }
-
-        lag.pop_back();
     }
 }
 

--- a/entwine/tree/manifest.cpp
+++ b/entwine/tree/manifest.cpp
@@ -221,6 +221,16 @@ Manifest::Manifest(const Json::Value& json)
     }
 }
 
+Origin Manifest::find(const std::string& search) const
+{
+    for (std::size_t i(0); i < size(); ++i)
+    {
+        if (m_paths[i].path().find(search) != std::string::npos) return i;
+    }
+
+    return invalidOrigin;
+}
+
 void Manifest::append(const Manifest& other)
 {
     for (const auto& info : other.m_paths)

--- a/entwine/tree/manifest.hpp
+++ b/entwine/tree/manifest.hpp
@@ -158,8 +158,10 @@ public:
     std::size_t size() const { return m_paths.size(); }
     const std::vector<FileInfo>& paths() const { return m_paths; }
 
-    FileInfo& get(Origin origin) { return m_paths[origin]; }
-    const FileInfo& get(Origin origin) const { return m_paths[origin]; }
+    Origin find(const std::string& path) const;
+
+    FileInfo& get(Origin origin) { return m_paths.at(origin); }
+    const FileInfo& get(Origin origin) const { return m_paths.at(origin); }
     void set(Origin origin, FileInfo::Status status)
     {
         countStatus(status);

--- a/entwine/types/bounds.cpp
+++ b/entwine/types/bounds.cpp
@@ -123,6 +123,13 @@ void Bounds::grow(const Point& p)
     setMid();
 }
 
+void Bounds::shrink(const Bounds& other)
+{
+    m_min = Point::max(m_min, other.min());
+    m_max = Point::min(m_max, other.max());
+    setMid();
+}
+
 Bounds Bounds::growBy(double ratio) const
 {
     const Point delta(

--- a/entwine/types/bounds.hpp
+++ b/entwine/types/bounds.hpp
@@ -228,6 +228,7 @@ public:
 
     void grow(const Bounds& bounds);
     void grow(const Point& p);
+    void shrink(const Bounds& bounds);
 
     bool isCubic() const
     {

--- a/entwine/types/metadata.hpp
+++ b/entwine/types/metadata.hpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include <entwine/types/point.hpp>
+
 namespace Json { class Value; }
 
 namespace entwine

--- a/kernel/entwine.cpp
+++ b/kernel/entwine.cpp
@@ -40,6 +40,8 @@ namespace
             "\tKernels:\n"
             "\t\tbuild\n"
             "\t\t\tBuild (or continue to build) an index\n"
+            "\t\tinfer\n"
+            "\t\t\tAggregate information for an unindexed dataset\n"
             "\t\tmerge\n"
             "\t\t\tMerge colocated previously built subsets\n";
     }


### PR DESCRIPTION
Implement [comparison query operators](https://docs.mongodb.com/manual/reference/operator/query-comparison/) and [logical query operators](https://docs.mongodb.com/manual/reference/operator/query-logical/) to support arbitrary filtering during queries.  Filters are passed in via JSON structure during a `read` query.  

The `Origin` dimension and pseudo-dimension `Path` are spatially optimized during traversal.  Only `$eq` and `$in` are allowed for these dimensions - no inequalities or `$nin` queries for these.