### PR TITLE
Simplify the API for scaled/offset resource access

### DIFF
--- a/entwine/reader/reader.hpp
+++ b/entwine/reader/reader.hpp
@@ -118,11 +118,9 @@ public:
     bool exists(const Id& id) const { return m_ids.count(id); }
 
 private:
-    const Bounds& bounds() const;
     Bounds localize(
             const Bounds& inBounds,
-            const Scale* scale,
-            const Offset* offset) const;
+            const Delta& localDelta) const;
 
     arbiter::Endpoint m_endpoint;
 

--- a/entwine/types/bounds.cpp
+++ b/entwine/types/bounds.cpp
@@ -39,7 +39,7 @@ Bounds::Bounds(const Point& min, const Point& max)
     }
 }
 
-Bounds::Bounds(const Json::Value& json) : m_min(), m_max(), m_mid()
+Bounds::Bounds(const Json::Value& json, const Delta* delta)
 {
     if (!json.isArray() || (json.size() != 4 && json.size() != 6))
     {
@@ -70,8 +70,7 @@ Bounds::Bounds(const Json::Value& json) : m_min(), m_max(), m_mid()
                 json.get(Json::ArrayIndex(3), 0).asDouble());
     }
 
-    Bounds self(m_min, m_max);
-    *this = self;
+    *this = Bounds(m_min, m_max).deltify(delta);
 }
 
 Bounds::Bounds(const Point& center, const double radius)
@@ -153,6 +152,7 @@ Bounds Bounds::deltify(const Delta* delta) const
 
 Bounds Bounds::deltify(const Delta& delta) const
 {
+    if (delta.empty()) return *this;
     return Bounds(
             Point::scale(min(), delta.scale(), delta.offset()),
             Point::scale(max(), delta.scale(), delta.offset()));
@@ -166,6 +166,7 @@ Bounds Bounds::undeltify(const Delta* delta) const
 
 Bounds Bounds::undeltify(const Delta& delta) const
 {
+    if (delta.empty()) return *this;
     return Bounds(
             Point::unscale(min(), delta.scale(), delta.offset()),
             Point::unscale(max(), delta.scale(), delta.offset()));

--- a/entwine/types/bounds.hpp
+++ b/entwine/types/bounds.hpp
@@ -30,7 +30,7 @@ public:
     Bounds() = default;
     Bounds(const Point& min, const Point& max);
     Bounds(const Point& center, double radius);
-    Bounds(const Json::Value& json);
+    Bounds(const Json::Value& json, const Delta* delta = nullptr);
     Bounds(double xMin, double yMin, double xMax, double yMax);
     Bounds(
             double xMin,
@@ -251,6 +251,7 @@ public:
     Bounds deltify(const Delta& delta) const;
     Bounds undeltify(const Delta* delta) const;
     Bounds undeltify(const Delta& delta) const;
+
     Bounds growBy(double ratio) const;
 
     std::vector<Bounds> explode() const;

--- a/entwine/types/delta.hpp
+++ b/entwine/types/delta.hpp
@@ -22,7 +22,7 @@ namespace entwine
 class Delta
 {
 public:
-    Delta() : m_scale(1, 1, 1), m_offset(0, 0, 0) { }
+    Delta() : m_scale(1), m_offset(0) { }
 
     Delta(const Scale& scale, const Offset& offset = Offset())
         : m_scale(scale)
@@ -30,8 +30,14 @@ public:
     { }
 
     Delta(const Scale* scale, const Offset* offset)
-        : m_scale(scale ? *scale : Point(1, 1, 1))
-        , m_offset(offset ? *offset : Point(0, 0, 0))
+        : m_scale(scale ? *scale : Scale(1))
+        , m_offset(offset ? *offset : Offset(0))
+    { }
+
+    Delta(const Delta* delta)
+        : Delta(
+                delta ? delta->scale() : Scale(1),
+                delta ? delta->offset() : Offset(0))
     { }
 
     Delta(const Json::Value& json)
@@ -66,6 +72,7 @@ public:
     Offset& offset() { return m_offset; }
 
     bool empty() const { return m_scale == Scale(1) && m_offset == Offset(0); }
+    bool exists() const { return !empty(); }
 
     Delta inverse() const
     {

--- a/entwine/types/metadata.hpp
+++ b/entwine/types/metadata.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include <entwine/types/bounds.hpp>
 #include <entwine/types/format-types.hpp>
 
 namespace Json { class Value; }
@@ -24,7 +25,6 @@ namespace entwine
 namespace arbiter { class Endpoint; }
 namespace cesium { class Settings; }
 
-class Bounds;
 class Delta;
 class Format;
 class Manifest;
@@ -42,7 +42,7 @@ class Metadata
 
 public:
     Metadata(
-            const Bounds& boundsNative,
+            const Bounds& nativeBounds,
             const Schema& schema,
             const Structure& structure,
             const Structure& hierarchyStructure,
@@ -68,11 +68,19 @@ public:
 
     void save(const arbiter::Endpoint& endpoint) const;
 
-    const Bounds& boundsNative() const { return *m_boundsNative; }
+    const Bounds& bounds() const { return *m_bounds; }
     const Bounds& boundsConforming() const { return *m_boundsConforming; }
     const Bounds& boundsEpsilon() const { return *m_boundsEpsilon; }
-    const Bounds& bounds() const { return *m_bounds; }
     const Bounds* boundsSubset() const;
+    const Bounds  boundsNative() const
+    {
+        return m_bounds->undeltify(delta());
+    }
+    const Bounds  boundsNativeConforming() const
+    {
+        return m_boundsConforming->undeltify(delta());
+    }
+
     const Schema& schema() const { return *m_schema; }
     const Structure& structure() const { return *m_structure; }
     const Structure& hierarchyStructure() const
@@ -112,16 +120,17 @@ private:
     std::vector<std::string>& errors() { return m_errors; }
     std::string& srs() { return m_srs; }
 
-    // The native bounds here is the only one without scale/offset applied.
-    std::unique_ptr<Bounds> m_boundsNative;
+    std::unique_ptr<Delta> m_delta;
+
+    // All bounds have scale/offset already applied, if they exist.
     std::unique_ptr<Bounds> m_boundsConforming;
     std::unique_ptr<Bounds> m_boundsEpsilon;
     std::unique_ptr<Bounds> m_bounds;
+
     std::unique_ptr<Schema> m_schema;
     std::unique_ptr<Structure> m_structure;
     std::unique_ptr<Structure> m_hierarchyStructure;
     std::unique_ptr<Manifest> m_manifest;
-    std::unique_ptr<Delta> m_delta;
     std::unique_ptr<Format> m_format;
     std::unique_ptr<Reprojection> m_reprojection;
     std::unique_ptr<Subset> m_subset;

--- a/entwine/types/point.hpp
+++ b/entwine/types/point.hpp
@@ -189,6 +189,15 @@ public:
         return (d - origin) / scale + origin - offset;
     }
 
+    static double scaleInversed(
+            double d,
+            double origin,
+            double scaleInversed,
+            double offset)
+    {
+        return (d - origin) * scaleInversed + origin - offset;
+    }
+
     static Point unscale(
             const Point& p,
             const Point& scale,

--- a/entwine/util/json.hpp
+++ b/entwine/util/json.hpp
@@ -177,6 +177,9 @@ namespace extraction
     std::vector<T> doExtract(const Json::Value& json, F f)
     {
         std::vector<T> result;
+
+        if (json.isNull() || !json.isArray()) return result;
+
         result.reserve(json.size());
 
         for (Json::ArrayIndex i(0); i < json.size(); ++i)

--- a/kernel/infer.cpp
+++ b/kernel/infer.cpp
@@ -290,6 +290,11 @@ void Kernel::infer(std::vector<std::string> args)
     {
         std::cout << "Scale:  " << delta->scale() << std::endl;
         std::cout << "Offset: " << delta->offset() << std::endl;
+        std::cout << "Transformed: " <<
+            inference.nativeBounds().deltify(*delta) << std::endl;
     }
+
+    std::cout << "Cubified: " <<
+        inference.nativeBounds().cubeify(inference.delta()) << std::endl;
 }
 

--- a/test/unit/build.cpp
+++ b/test/unit/build.cpp
@@ -147,16 +147,11 @@ TEST_P(BuildTest, Verify)
     // Bounds.
     const Bounds bounds(meta["bounds"]);
     const Bounds boundsConforming(meta["boundsConforming"]);
-    const Bounds boundsNative(meta["boundsNative"]);
 
     EXPECT_EQ(boundsConforming, expect.boundsConforming);
 
     EXPECT_TRUE(bounds.isCubic());
     EXPECT_TRUE(bounds.contains(boundsConforming));
-
-    EXPECT_EQ(
-            boundsNative.scale(delta.scale(), delta.offset()),
-            boundsConforming);
 
     // Schema.
     const Schema schema(meta["schema"]);
@@ -183,9 +178,10 @@ TEST_P(BuildTest, Verify)
     Cache cache(32);
     Reader r(outPath, cache);
 
+    const Delta empty;
     test::Octree o(
             bounds,
-            delta,
+            empty,
             meta["structure"]["nullDepth"].asUInt64(),
             meta["structure"]["coldDepth"].asUInt64());
 
@@ -213,6 +209,8 @@ TEST_P(BuildTest, Verify)
         {
             q = q.get(toDir((depth + n) % 8));
             const std::size_t np(r.query(q, depth).size() / schema.pointSize());
+
+            // const Bounds s(q.deltify(delta));
             ASSERT_EQ(np, o.query(q, depth).size()) <<
                 " B: " << bounds << " D: " << depth << std::endl;
         }
@@ -292,9 +290,9 @@ namespace scaled
     const Bounds actualScaledBounds(
             actualBounds.scale(delta.scale(), delta.offset()));
 
-    Expectations one(single, actualScaledBounds, delta);
-    Expectations two(multi, actualScaledBounds, delta);
-    Expectations con(continued, actualScaledBounds, delta);
+    Expectations one(single, actualBounds, delta);
+    Expectations two(multi, actualBounds, delta);
+    Expectations con(continued, actualBounds, delta);
 
     INSTANTIATE_TEST_CASE_P(
             Scaled,


### PR DESCRIPTION
The recent scale/offset API exposed bounds as already-transformed, and any client-side transformations had to be relative to those pre-transformed bounds.  This got confusing if the server already had a transformation and you wanted a different one - you had to keep track of both.  Client logic was also more confusing than necessary since it wasn't obvious what a query would return - without some careful thought.

This behavior is now modified to always expose bounds in their native form for outward-facing interfaces, like metadata info and data queries.  Passing a client scale/offset identical to the stored scale/offset is essentially a no-op, providing the data directly in its storage format.  This allows clients to access resources derived from the same sources uniformly, no matter how their storage has been transformed.

It's a bit disruptive since any of the new scaled indexes built from the past couple of weeks is no longer good.  The metadata could be trivially patched, but there probably aren't very many of these out there so I'll hold off on scripting that up unless it's needed.