### PR TITLE
Remove install rules from gtest

### DIFF
--- a/test/gtest-1.8.0/CMakeLists.txt
+++ b/test/gtest-1.8.0/CMakeLists.txt
@@ -101,14 +101,6 @@ endif()
 
 ########################################################################
 #
-# Install rules
-install(TARGETS gtest gtest_main
-  DESTINATION lib)
-install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
-  DESTINATION include)
-
-########################################################################
-#
 # Samples on how to link user tests with gtest or gtest_main.
 #
 # They are not built by default.  To build them, set the


### PR DESCRIPTION
entwine shouldn't install gtest.