### PR TITLE
support windows builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 credentials.json
 CMakeCache.txt
+CMakeFiles/
 
 .DS_Store
 build/*
@@ -9,3 +10,6 @@ test/data/*
 !test/data/generate
 !test/data/generate-ellipsoid.cpp
 
+*.vcxproj
+*.vcxproj.filters
+*.sln

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,13 +107,27 @@ set(OBJS
     $<TARGET_OBJECTS:util>
 )
 
-add_library(entwine SHARED ${OBJS})
+if (MSVC)
+    add_library(entwine STATIC ${OBJS})
+else()
+    add_library(entwine SHARED ${OBJS})
+endif()
 
-target_link_libraries(entwine pdalcpp lzma dl)
+if (MSVC)
+    find_library(LZMA_LIBRARY liblzma PATHS "${CMAKE_INSTALL_PREFIX}/lib")
+    target_link_libraries(entwine pdalcpp pdal_util ${LZMA_LIBRARY})
+else()
+    target_link_libraries(entwine pdalcpp lzma dl)
+endif()
 
 if (ENTWINE_JSONCPP_INCLUDE_DIR)
     MESSAGE("Linking system JsonCpp")
-    target_link_libraries(entwine jsoncpp)
+    if (MSVC)
+        find_library(JSONCPP_LIBRARY jsoncpp PATHS "${CMAKE_INSTALL_PREFIX}/lib")
+        target_link_libraries(entwine ${JSONCPP_LIBRARY})
+    else()
+        target_link_libraries(entwine jsoncpp)
+    endif()
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,9 +166,11 @@ install(
     FILES "${PROJECT_BINARY_DIR}/entwine-config.cmake"
     DESTINATION lib/cmake/entwine)
 
-add_subdirectory(test/gtest-1.8.0)
-include_directories(entwine test/gtest-1.8.0/include test/gtest-1.8.0)
-add_subdirectory(test)
+if (NOT MSVC)
+    add_subdirectory(test/gtest-1.8.0)
+    include_directories(entwine test/gtest-1.8.0/include test/gtest-1.8.0)
+    add_subdirectory(test)
+endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpack.cmake")
 add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
     add_definitions(${CMAKE_CXX_FLAGS} "-fPIC")
 endif()
 
+if (MSVC)
+    # prevents clashes between macros min\max and std::min\std::max
+    add_definitions(${CMAKE_CXX_FLAGS} "/DNOMINMAX")
+endif(MSVC)
+
 set(ENTWINE_VERSION_MAJOR 1 CACHE STRING "Entwine major version" FORCE)
 set(ENTWINE_VERSION_MINOR 0 CACHE STRING "Entwine major version" FORCE)
 set(ENTWINE_VERSION_PATCH 0 CACHE STRING "Entwine major version" FORCE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,6 @@ matrix:
 environment:
   OSGEO4W_ROOT: C:\OSGeo4W64
 
-  matrix:
-    - PDAL_OPTIONAL_COMPONENTS: OFF
-    - PDAL_OPTIONAL_COMPONENTS: ON
-
 # Should speed up repository cloning
 shallow_clone: true
 clone_depth: 5
@@ -32,18 +28,9 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
-  # make a temp directory for downloading osgeo4w-setup.exe
-  # this may not matter as much if part of the install step, as pdal has
-  # already been cloned, otherwise git would complain about a non-empty
-  # directory
-  - ps: mkdir C:\temp | out-null
   - ps: mkdir $env:OSGEO4W_ROOT | out-null
   # make an install directory for packacing
   - ps: mkdir C:\pdalbin | out-null
-  # get the OSGeo installer
-  - ps: (new-object net.webclient).DownloadFile("http://download.osgeo.org/osgeo4w/osgeo4w-setup-x86_64.exe", "C:\temp\osgeo4w-setup.exe")
-  # and install our dependencies
-  - C:\temp\osgeo4w-setup.exe -q -k -r -A -s http://download.osgeo.org/osgeo4w/ -a x86_64 -P boost-devel,eigen,gdal,geos,hexer,iconv,laszip,libgeotiff,libpq,libtiff,libxml2,nitro,pcl,points2grid,proj,python-numpy,zlib -R %OSGEO4W_ROOT% > NUL
   # call our Entwine install script
   - call .\\scripts\\appveyor\\config.cmd
 
@@ -53,18 +40,7 @@ build:
   verbosity: minimal
 
 after_build:
-  - 7z a pdal.zip %APPVEYOR_BUILD_FOLDER%\bin\*.*
-
-test_script:
-  # FIXME: Clear PATH to avoid OSGeo4W loading incompatible DLLs
-  - set PATH=
-  - set PATH=%OSGEO4W_ROOT%\bin;C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\7-Zip;C:\Program Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Python27;C:\Tools\GitVersion;C:\Program Files (x86)\CMake\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;C:\Program Files\AppVeyor\BuildAgent\
-  - set PYTHONHOME=C:\Python27-x64
-  - set PYTHONPATH=%PYTHONHOME%\Lib;%OSGEO4W_ROOT%\apps\Python27\lib\site-packages
-  - echo %PATH%
-  - set GDAL_DATA=%OSGEO4W_ROOT%\share\epsg_csv
-  - set PROJ_LIB=%OSGEO4W_ROOT%\share\proj
-  - ctest -V --output-on-failure -C Release
+  - 7z a entwine.zip %APPVEYOR_BUILD_FOLDER%\bin\*.*
 
 artifacts:
   - path: entwine.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,77 @@
+version: 1.0.{build}
+
+os: Visual Studio 2015
+
+platform: x64
+
+configuration: Release
+
+matrix:
+  fast_finish: true
+
+environment:
+  OSGEO4W_ROOT: C:\OSGeo4W64
+
+  matrix:
+    - PDAL_OPTIONAL_COMPONENTS: OFF
+    - PDAL_OPTIONAL_COMPONENTS: ON
+
+# Should speed up repository cloning
+shallow_clone: true
+clone_depth: 5
+
+# Uncomment if you need to debug AppVeyor session (https://www.appveyor.com/docs/how-to/rdp-to-build-worker)
+# on_finish:
+# - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+init:
+  - set PYTHONHOME=C:\Python27-x64
+  - set PYTHONPATH=%PYTHONHOME%\Lib;%OSGEO4W_ROOT%\apps\Python27\lib\site-packages
+  - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+  - set PATH=%PYTHONHOME%;%PATH%
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+install:
+  # make a temp directory for downloading osgeo4w-setup.exe
+  # this may not matter as much if part of the install step, as pdal has
+  # already been cloned, otherwise git would complain about a non-empty
+  # directory
+  - ps: mkdir C:\temp | out-null
+  - ps: mkdir $env:OSGEO4W_ROOT | out-null
+  # make an install directory for packacing
+  - ps: mkdir C:\pdalbin | out-null
+  # get the OSGeo installer
+  - ps: (new-object net.webclient).DownloadFile("http://download.osgeo.org/osgeo4w/osgeo4w-setup-x86_64.exe", "C:\temp\osgeo4w-setup.exe")
+  # and install our dependencies
+  - C:\temp\osgeo4w-setup.exe -q -k -r -A -s http://download.osgeo.org/osgeo4w/ -a x86_64 -P boost-devel,eigen,gdal,geos,hexer,iconv,laszip,libgeotiff,libpq,libtiff,libxml2,nitro,pcl,points2grid,proj,python-numpy,zlib -R %OSGEO4W_ROOT% > NUL
+  # call our Entwine install script
+  - call .\\scripts\\appveyor\\config.cmd
+
+build:
+  parallel: true
+  project: entwine.sln
+  verbosity: minimal
+
+after_build:
+  - 7z a pdal.zip %APPVEYOR_BUILD_FOLDER%\bin\*.*
+
+test_script:
+  # FIXME: Clear PATH to avoid OSGeo4W loading incompatible DLLs
+  - set PATH=
+  - set PATH=%OSGEO4W_ROOT%\bin;C:\Program Files (x86)\MSBuild\14.0\Bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\7-Zip;C:\Program Files\Microsoft Windows Performance Toolkit\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Python27;C:\Tools\GitVersion;C:\Program Files (x86)\CMake\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin;C:\Program Files\AppVeyor\BuildAgent\
+  - set PYTHONHOME=C:\Python27-x64
+  - set PYTHONPATH=%PYTHONHOME%\Lib;%OSGEO4W_ROOT%\apps\Python27\lib\site-packages
+  - echo %PATH%
+  - set GDAL_DATA=%OSGEO4W_ROOT%\share\epsg_csv
+  - set PROJ_LIB=%OSGEO4W_ROOT%\share\proj
+  - ctest -V --output-on-failure -C Release
+
+artifacts:
+  - path: entwine.zip
+    name: entwinemaster
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false

--- a/entwine/tree/splitter.hpp
+++ b/entwine/tree/splitter.hpp
@@ -37,8 +37,6 @@ public:
         mutable UniqueT t;
     };
 
-    using SlotType = Splitter<T>::Slot;
-
     Splitter(const Structure& structure)
         : m_structure(structure)
         , m_base()

--- a/entwine/types/point.hpp
+++ b/entwine/types/point.hpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <sstream>
 #include <vector>
+#include <algorithm>
 
 #include <json/json.h>
 

--- a/entwine/util/lzma.cpp
+++ b/entwine/util/lzma.cpp
@@ -85,7 +85,7 @@ std::unique_ptr<std::vector<char>> run(
 std::unique_ptr<std::vector<char>> Compression::compressLzma(
         const std::vector<char>& in)
 {
-    lzma_stream stream(LZMA_STREAM_INIT);
+    lzma_stream stream = LZMA_STREAM_INIT;
     const lzma_ret ret(lzma_easy_encoder(&stream, mode, LZMA_CHECK_CRC64));
 
     if (ret != LZMA_OK) check(ret);
@@ -117,7 +117,7 @@ std::unique_ptr<std::vector<char>> Compression::decompressLzma(
         throw std::runtime_error("Possible LZMA partial download detected");
     }
 
-    lzma_stream stream(LZMA_STREAM_INIT);
+    lzma_stream stream = LZMA_STREAM_INIT;
 
     const lzma_ret ret(
             lzma_auto_decoder(

--- a/entwine/util/pool.cpp
+++ b/entwine/util/pool.cpp
@@ -11,6 +11,7 @@
 #include <entwine/util/pool.hpp>
 
 #include <iostream>
+#include <string>
 
 namespace entwine
 {

--- a/entwine/util/stack-trace.hpp
+++ b/entwine/util/stack-trace.hpp
@@ -29,6 +29,7 @@ namespace
     std::mutex mutex;
 }
 
+#ifndef _WIN32
 inline void stackTrace()
 {
     std::lock_guard<std::mutex> lock(mutex);
@@ -74,6 +75,7 @@ inline void stackTrace()
 
     free(symbols);
 }
+#endif
 
 template<typename Signal>
 inline void stackTraceOn(Signal s)

--- a/scripts/appveyor/config.cmd
+++ b/scripts/appveyor/config.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+cmake -Wno-dev -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:\pdalbin .

--- a/scripts/appveyor/install.cmd
+++ b/scripts/appveyor/install.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+cmake --build . --config Release --target INSTALL


### PR DESCRIPTION
This PR is a work in progress.

Support windows builds by
- tweaking the top-level `CMakeLists.txt`:
  - locate some libraries using `find_libraries` (lzma, jsoncpp, pdal_util). For simplicity's sake, we assume we will find those libraries in the same tree as PDAL (default is `C:\pdalbin`)
  - disable tests on MSVC (I couldn't compile the test projects)
- fix the known `NOMINMAX` issue on MSVC (see http://stackoverflow.com/q/4913922)
- add some `#include` to appease MSVC

Also, add scripts to prepare for a future AppVeyor automation (inspired by PDAL).

Tested on CMake generator `Visual Studio 14 2015 Win64`.