### PR TITLE
cesium: add normal support

### DIFF
--- a/entwine/formats/cesium/feature-table.hpp
+++ b/entwine/formats/cesium/feature-table.hpp
@@ -28,7 +28,8 @@ public:
 
     FeatureTable(
             const std::vector<Point>& points,
-            const std::vector<Color>& colors);
+            const std::vector<Color>& colors,
+            const std::vector<Point>& normals);
 
     // Not really used anywhere, but may be useful for output validation.
     FeatureTable(const Json::Value& json, const char* pos);
@@ -41,14 +42,17 @@ public:
     {
         return
             m_points.size() * 3 * sizeof(float) +
+            m_normals.size() * 3 * sizeof(float) +
             m_colors.size() * 3 * sizeof(uint8_t);
     }
 
 private:
     void summarizePoints() const;
     void summarizeColors() const;
+    void summarizeNormals() const;
 
     std::vector<Point> m_points;
+    std::vector<Point> m_normals;
     std::vector<Color> m_colors;
 };
 

--- a/entwine/formats/cesium/tile-builder.hpp
+++ b/entwine/formats/cesium/tile-builder.hpp
@@ -65,6 +65,7 @@ private:
 
     std::size_t m_divisor;
     bool m_hasColor;
+    bool m_hasNormals;
     std::map<std::size_t, Color> m_tileColors;
     std::map<std::size_t, TileData> m_data;
 

--- a/entwine/formats/cesium/tile.hpp
+++ b/entwine/formats/cesium/tile.hpp
@@ -34,8 +34,9 @@ public:
 
     Tile(
             const std::vector<Point>& points,
-            const std::vector<Color>& colors)
-        : m_featureTable(points, colors)
+            const std::vector<Color>& colors,
+            const std::vector<Point>& normals)
+        : m_featureTable(points, colors, normals)
     { }
 
     std::vector<char> asBinary() const;
@@ -64,14 +65,16 @@ private:
 class TileData
 {
 public:
-    TileData(std::size_t numPoints, bool hasColor)
+    TileData(std::size_t numPoints, bool hasColor, bool hasNormals)
     {
         points.reserve(numPoints);
         if (hasColor) colors.reserve(numPoints);
+        if (hasNormals) normals.reserve(numPoints);
     }
 
     std::vector<Point> points;
     std::vector<Color> colors;
+    std::vector<Point> normals;
 };
 
 } // namespace cesium

--- a/entwine/tree/chunk.cpp
+++ b/entwine/tree/chunk.cpp
@@ -199,7 +199,7 @@ void SparseChunk::tile() const
         const std::size_t tick(tilePair.first);
         const auto& tileData(tilePair.second);
 
-        cesium::Tile tile(tileData.points, tileData.colors);
+        cesium::Tile tile(tileData.points, tileData.colors, tileData.normals);
 
         io::ensurePut(
                 endpoint,
@@ -284,7 +284,7 @@ void ContiguousChunk::tile() const
         const std::size_t tick(tilePair.first);
         const auto& tileData(tilePair.second);
 
-        cesium::Tile tile(tileData.points, tileData.colors);
+        cesium::Tile tile(tileData.points, tileData.colors, tileData.normals);
 
         io::ensurePut(
                 endpoint,


### PR DESCRIPTION
Whenever the dimensions `NormalX`, `NormalY` and `NormalZ` are present
in the `PointView`, the cesium output shall contain those values.