### PR TITLE
DOC: fix issue with Docker command in Quickstart

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -21,11 +21,11 @@ Now we have Entwine data at ``~/entwine/abc``.  We could have also passed a wild
 
 ::
 
-    docker run -it -v $HOME/entwine:/opt/data -p 8080:80 connormanning/greyhound
+    docker run -it -v $HOME/entwine:/opt/data -p 8080:8080 connormanning/greyhound
 
 |
 
-You may need to forward port 8080 from your docker virtual machine to your host OS; `this post <https://jlordiales.me/2015/04/02/boot2docker-port-forward/>`_ describes one way to do this.
+You may need to forward port 8080 from your docker virtual machine to your host OS; `this post <https://jlordiales.me/2015/04/02/boot2docker-port-forward/>`_ describes one way to do this on macOS.
 For the impatient, use this one-liner:
 
 ::


### PR DESCRIPTION
The port mapping is ``hostPort:containerPort``, and the default container port is 8080:

    05:50:34:36 LOG         Read paths: ["/greyhound","~/greyhound","/entwine","~/entwine","/opt/data","/usr/lib/node_modules/greyhound-server/data"]
    05:50:34:38 LOG         Cache size: 524288000 (500MB)
    05:50:34:38 LOG         Threads identified: 2
    05:50:34:38 LOG         UV pool size: 4
    05:50:34:93 LOG HTTP server running on port 8080

Also add "on macOS" to the port forwarding link, it's not applicable to Windows or Linux.