### PR TITLE
Batch table implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@ test/data/*
 *.vcxproj
 *.vcxproj.filters
 *.sln
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
+# Visual C++ cache files
+ipch/
+
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ endif()
 
 if (MSVC)
     find_library(LZMA_LIBRARY liblzma PATHS "${CMAKE_INSTALL_PREFIX}/lib")
+    target_include_directories(util PRIVATE ${LIBLZMA_INCLUDE_DIR})
 else()
     target_link_libraries(entwine lzma)
 endif()

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -457,6 +457,15 @@ For S3, if `AWSCLI`_ has been installed, then the credentials will be picked up
 from there, making this field unnecessary.  See the S3_ section for more
 information.
 
+
+To update Entwine's arbiter.cpp and arbiter.hpp source files from the Arbiter
+source repository, Arbiter must be amalgamated using the following command:
+
+.. code-block:: shell
+
+	python amalgamate.py -c entwine -j
+
+
 .. _AWSCLI: https://aws.amazon.com/cli/
 
 Storage

--- a/entwine/formats/cesium/CMakeLists.txt
+++ b/entwine/formats/cesium/CMakeLists.txt
@@ -3,6 +3,7 @@ set(BASE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set(
     SOURCES
+    "${BASE}/batch-reference.cpp"
     "${BASE}/batch-table.cpp"
     "${BASE}/feature-table.cpp"
     "${BASE}/settings.cpp"
@@ -13,6 +14,7 @@ set(
 
 set(
     HEADERS
+    "${BASE}/batch-reference.hpp"
     "${BASE}/batch-table.hpp"
     "${BASE}/feature-table.hpp"
     "${BASE}/settings.hpp"

--- a/entwine/formats/cesium/README.md
+++ b/entwine/formats/cesium/README.md
@@ -3,6 +3,15 @@
 ## What's this?
 For now, see instructions [here](https://github.com/connormanning/entwine-cesium-pages) to build for Cesium display.
 
+## Batch tables
+Specific point dimensions may be written to a tile's batch table. Only numeric dimensions are supported at present, and values
+will be written to the binary portion of the batch table. To utilise this feature, add a "batchTable" property to the cesium
+format configuration, taking an array of dimension names:
+
+```json
+"batchTable": [ "Dimension1", ... ]
+```
+
 ## Other notes
 For now, subset builds and continued build are not supported when building with Cesium output.  This will be available soon.
 

--- a/entwine/formats/cesium/batch-reference.cpp
+++ b/entwine/formats/cesium/batch-reference.cpp
@@ -1,0 +1,100 @@
+/******************************************************************************
+* Copyright (c) 2018, Andrew Polden
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <entwine/formats/cesium/batch-reference.hpp>
+
+#include <json/json.h>
+
+namespace entwine
+{
+namespace cesium
+{
+
+Json::Value BatchReference::getJson() const
+{
+    Json::Value json;
+    json["byteOffset"] = Json::UInt64(m_byteOffset);
+    json["componentType"] = componentTypeNames.at(m_componentType);
+    json["type"] = typeNames.at(m_type);
+
+    return json;
+};
+
+std::size_t BatchReference::bytes() const
+{
+    return componentTypeSizes.at(m_componentType) * typeSizes.at(m_type);
+};
+
+using DT = pdal::Dimension::Type;
+using CT = BatchReference::ComponentType;
+using T = BatchReference::Type;
+
+const CT BatchReference::findComponentType(DT type)
+{
+    const auto it(componentTypes.find(type));
+
+    if (it == componentTypes.end())
+        throw std::runtime_error("Dimension type not supported by batch table.");
+    
+    return it->second;
+};
+
+const std::unordered_map<const DT, const CT> BatchReference::componentTypes = {
+    { DT::Signed8, CT::Byte },
+    { DT::Unsigned8, CT::UnsignedByte },
+    { DT::Signed16, CT::Short },
+    { DT::Unsigned16, CT::UnsignedShort },
+    { DT::Signed32, CT::Int },
+    { DT::Unsigned32, CT::UnsignedInt },
+    { DT::Float, CT::Float },
+    { DT::Double, CT::Double }
+};
+
+const std::unordered_map<const CT, const char*> BatchReference::componentTypeNames = {
+    { CT::Byte, "BYTE" },
+    { CT::UnsignedByte, "UNSIGNED_BYTE" },
+    { CT::Short, "SHORT" },
+    { CT::UnsignedShort, "UNSIGNED_SHORT" },
+    { CT::Int, "INT" },
+    { CT::UnsignedInt, "UNSIGNED_INT" },
+    { CT::Float, "FLOAT" },
+    { CT::Double, "DOUBLE" }
+};
+
+const std::unordered_map<const CT, std::uint8_t> BatchReference::componentTypeSizes = {
+    { CT::Byte, 1 },
+    { CT::UnsignedByte, 1 },
+    { CT::Short, 2 },
+    { CT::UnsignedShort, 2 },
+    { CT::Int, 4 },
+    { CT::UnsignedInt, 4 },
+    { CT::Float, 4 },
+    { CT::Double, 8 }
+};
+
+
+const std::unordered_map<const T, const char*> BatchReference::typeNames = {
+    { T::Scalar, "SCALAR" },
+    { T::Vec2, "VEC2" },
+    { T::Vec3, "VEC3" },
+    { T::Vec4, "VEC4" }
+};
+
+const std::unordered_map<const T, std::uint8_t> BatchReference::typeSizes = {
+    { T::Scalar, 1 },
+    { T::Vec2, 2 },
+    { T::Vec3, 3 },
+    { T::Vec4, 4 }
+};
+
+} // namespace cesium
+} // namespace entwine

--- a/entwine/formats/cesium/batch-reference.hpp
+++ b/entwine/formats/cesium/batch-reference.hpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+* Copyright (c) 2018, Andrew Polden
+*
+* Entwine -- Point cloud indexing
+*
+* Entwine is available under the terms of the LGPL2 license. See COPYING
+* for specific license text and more information.
+*
+******************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#include <pdal/DimUtil.hpp>
+
+#include <json/json.h>
+
+namespace entwine
+{
+namespace cesium
+{
+
+class BatchReference
+{
+public:
+    enum class ComponentType
+    {
+        Byte,
+        UnsignedByte,
+        Short,
+        UnsignedShort,
+        Int,
+        UnsignedInt,
+        Float,
+        Double
+    };
+
+    enum class Type
+    {
+        Scalar,
+        Vec2,
+        Vec3,
+        Vec4,
+    };
+
+    BatchReference(std::string propertyName, std::size_t byteOffset, const ComponentType componentType, const Type type = Type::Scalar)
+        : m_propertyName(propertyName)
+        , m_byteOffset(byteOffset)
+        , m_componentType(componentType)
+        , m_type(type) { };
+
+    std::string name() const { return m_propertyName; };
+    std::size_t byteOffset() const { return m_byteOffset; };
+    Json::Value getJson() const;
+    std::size_t bytes() const;
+
+    static const ComponentType findComponentType(pdal::Dimension::Type);
+
+private:
+    const std::string m_propertyName;
+    const std::size_t m_byteOffset;
+    const ComponentType m_componentType;
+    const Type m_type;
+
+    // Mappings used for converting between the PDAL dimension type, the batch reference types, and their respective string representation and size.
+    static const std::unordered_map<const pdal::Dimension::Type, const ComponentType> componentTypes;
+    static const std::unordered_map<const ComponentType, const char*> componentTypeNames;
+    static const std::unordered_map<const ComponentType, std::uint8_t> componentTypeSizes;
+    static const std::unordered_map<const Type, const char*> typeNames;
+    static const std::unordered_map<const Type, std::uint8_t> typeSizes;
+};
+
+} // namespace cesium
+} // namespace entwine

--- a/entwine/formats/cesium/batch-table.cpp
+++ b/entwine/formats/cesium/batch-table.cpp
@@ -8,11 +8,12 @@
 *
 ******************************************************************************/
 
-#include <entwine/formats/cesium/feature-table.hpp>
+#include <entwine/formats/cesium/batch-table.hpp>
 
 #include <iostream>
 #include <stdexcept>
 
+#include <entwine/formats/cesium/settings.hpp>
 #include <entwine/formats/cesium/tile.hpp>
 
 namespace entwine
@@ -20,24 +21,67 @@ namespace entwine
 namespace cesium
 {
 
-BatchTable::BatchTable(const TileData& tileData)
-    : m_tileData(tileData)
+BatchTable::BatchTable(const Metadata& metadata, const TileData& tileData)
+    : m_metadata(metadata)
+    , m_tileData(tileData)
+    , m_table(metadata.schema())
+    , m_pointRef(m_table, 0)
 {
+    const auto& settings = *m_metadata.cesiumSettings();
+    const auto& dimNames(settings.batchTableDimensions());
+    m_batchReferences.reserve(dimNames.size());
+    const auto schema(metadata.schema());
+    size_t byteOffset = 0;
+
+    for (const auto& dimName : dimNames)
+    {
+        DimInfo dimInfo(schema.find(dimName));
+        
+        // All properties will be scalar for now.
+        m_batchReferences.emplace_back(dimName, byteOffset, BatchReference::findComponentType(dimInfo.type())); 
+        const auto& ref = m_batchReferences.back();
+
+        // It is necessary to retrieve the data here for later use; the point table's setPoint method cannot be used during calls to appendBinary.
+        // To this end, allocate space for the data and copy it over.
+        m_data.resize(byteOffset + m_tileData.pointIndices.size() * ref.bytes());
+
+        for (const auto index : m_tileData.pointIndices)
+        {
+            m_table.setPoint(index);
+            m_pointRef.getField(m_data.data() + byteOffset, dimInfo.id(), dimInfo.type());
+            byteOffset += ref.bytes();
+        }
+    }
 }
 
 Json::Value BatchTable::getJson() const
 {
     Json::Value json;
+
+    const auto& settings = *m_metadata.cesiumSettings();
+    const auto& dims(settings.batchTableDimensions());
+
+    for (const auto& ref : m_batchReferences)
+    {
+        json[ref.name()] = ref.getJson();
+    }
+
     return json;
 }
 
 void BatchTable::appendBinary(std::vector<char>& data) const
 {
+    data.insert(data.end(), m_data.begin(), m_data.end());
 }
 
 std::size_t BatchTable::bytes() const
 {
-    return 0;
+    return m_data.size();
+}
+
+const std::vector<Point>& BatchTable::points() const
+{
+    return m_tileData.points;
 }
 
 } // namespace cesium

--- a/entwine/formats/cesium/batch-table.hpp
+++ b/entwine/formats/cesium/batch-table.hpp
@@ -14,6 +14,9 @@
 
 #include <json/json.h>
 
+#include <entwine/formats/cesium/batch-reference.hpp>
+#include <entwine/types/binary-point-table.hpp>
+#include <entwine/types/metadata.hpp>
 #include <entwine/types/point.hpp>
 
 namespace entwine
@@ -26,7 +29,7 @@ class TileData;
 class BatchTable
 {
 public:
-    BatchTable(const TileData& tileData);
+    BatchTable(const Metadata& metadata, const TileData& tileData);
 
     Json::Value getJson() const;
     void appendBinary(std::vector<char>& data) const;
@@ -38,6 +41,12 @@ private:
     const std::vector<Point>& normals() const;
 
     const TileData& m_tileData;
+    const Metadata& m_metadata;
+    std::vector<BatchReference> m_batchReferences;
+    std::vector<char> m_data;
+
+    BinaryPointTable m_table;
+    pdal::PointRef m_pointRef;
 };
 
 } // namespace cesium

--- a/entwine/formats/cesium/settings.cpp
+++ b/entwine/formats/cesium/settings.cpp
@@ -10,6 +10,8 @@
 
 #include <entwine/formats/cesium/settings.hpp>
 
+#include <entwine/util/json.hpp>
+
 namespace entwine
 {
 namespace cesium
@@ -19,11 +21,13 @@ Settings::Settings(
         std::size_t tilesetSplit,
         double geometricErrorDivisor,
         std::string coloring,
-        bool truncate)
+        bool truncate,
+        std::vector<std::string> batchTableDimensions)
     : m_tilesetSplit(tilesetSplit)
     , m_geometricErrorDivisor(geometricErrorDivisor)
     , m_coloring(coloring)
     , m_truncate(truncate)
+    , m_batchTableDimensions(batchTableDimensions)
 {
     if (!m_tilesetSplit) m_tilesetSplit = 8;
     if (m_geometricErrorDivisor == 0.0) m_geometricErrorDivisor = 8.0;
@@ -34,7 +38,8 @@ Settings::Settings(const Json::Value& json)
             json["tilesetSplit"].asUInt64(),
             json["geometricErrorDivisor"].asDouble(),
             json["coloring"].asString(),
-            json["truncate"].asBool())
+            json["truncate"].asBool(),
+            extract<std::string>(json["batchTable"]))
 { }
 
 Json::Value Settings::toJson() const
@@ -44,6 +49,7 @@ Json::Value Settings::toJson() const
     json["geometricErrorDivisor"] = m_geometricErrorDivisor;
     if (m_coloring.size()) json["coloring"] = m_coloring;
     if (m_truncate) json["truncate"] = true;
+    if (m_batchTableDimensions.size()) json["batchTable"] = toJsonArray(m_batchTableDimensions);
     return json;
 }
 

--- a/entwine/formats/cesium/settings.hpp
+++ b/entwine/formats/cesium/settings.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include <json/json.h>
 
@@ -26,7 +27,8 @@ public:
             std::size_t tilesetSplit,
             double geometricErrorDivisor,
             std::string coloring,
-            bool truncate);
+            bool truncate,
+            std::vector<std::string> batchTableDimensions);
 
     Settings(const Json::Value& json);
 
@@ -36,12 +38,14 @@ public:
     double geometricErrorDivisor() const { return m_geometricErrorDivisor; }
     const std::string& coloring() const { return m_coloring; }
     bool truncate() const { return m_truncate; }
+    const std::vector<std::string>& batchTableDimensions() const { return m_batchTableDimensions; }
 
 private:
     std::size_t m_tilesetSplit;
     double m_geometricErrorDivisor;
     std::string m_coloring;
     bool m_truncate;    // If true, color/intensity should be scaled to 8 bits.
+    std::vector<std::string> m_batchTableDimensions;
 };
 
 } // namespace cesium

--- a/entwine/formats/cesium/tile-builder.cpp
+++ b/entwine/formats/cesium/tile-builder.cpp
@@ -28,6 +28,7 @@ TileBuilder::TileBuilder(const Metadata& metadata, const TileInfo& info)
     , m_divisor(divisor())
     , m_hasColor(false)
     , m_hasNormals(false)
+    , m_hasBatchTableDimensions(m_settings.batchTableDimensions().size())
     , m_table(m_schema)
     , m_pr(m_table, 0)
 {
@@ -47,7 +48,7 @@ TileBuilder::TileBuilder(const Metadata& metadata, const TileInfo& info)
         m_data.emplace(
                 std::piecewise_construct,
                 std::forward_as_tuple(p.first),
-                std::forward_as_tuple(p.second, m_hasColor, m_hasNormals));
+                std::forward_as_tuple(p.second, m_hasColor, m_hasNormals, m_hasBatchTableDimensions));
     }
 
     if (m_settings.coloring() == "tile")
@@ -72,8 +73,8 @@ void TileBuilder::push(std::size_t rawTick, const Cell& cell)
     for (const auto& single : cell)
     {
         m_table.setPoint(single);
-        if (delta)
 
+        if (delta)
         {
             selected.points.emplace_back(
                     Point::unscale(
@@ -122,6 +123,9 @@ void TileBuilder::push(std::size_t rawTick, const Cell& cell)
                 m_pr.getFieldAs<double>(normalYDim),
                 m_pr.getFieldAs<double>(normalZDim));
         }
+
+        // If batch table dimensions were specified, we must store the point index from which to extract them when building the table.
+        if (m_hasBatchTableDimensions) selected.pointIndices.emplace_back(single);
     }
 }
 

--- a/entwine/formats/cesium/tile-builder.hpp
+++ b/entwine/formats/cesium/tile-builder.hpp
@@ -66,6 +66,7 @@ private:
     std::size_t m_divisor;
     bool m_hasColor;
     bool m_hasNormals;
+    bool m_hasBatchTableDimensions;
     std::map<std::size_t, Color> m_tileColors;
     std::map<std::size_t, TileData> m_data;
 

--- a/entwine/formats/cesium/tile.hpp
+++ b/entwine/formats/cesium/tile.hpp
@@ -30,24 +30,26 @@ namespace cesium
 class TileData
 {
 public:
-    TileData(std::size_t numPoints, bool hasColor, bool hasNormals)
+    TileData(std::size_t numPoints, bool hasColor, bool hasNormals, bool hasBatchTableDimensions)
     {
         points.reserve(numPoints);
         if (hasColor) colors.reserve(numPoints);
         if (hasNormals) normals.reserve(numPoints);
+        if (hasBatchTableDimensions) pointIndices.reserve(numPoints);
     }
 
     std::vector<Point> points;
     std::vector<Color> colors;
     std::vector<Point> normals;
+    std::vector<const char*> pointIndices;
 };
 
 class Tile
 {
 public:
-    Tile(const TileData& tileData)
+    Tile(const Metadata& metadata, const TileData& tileData)
         : m_featureTable(tileData)
-        , m_batchTable(tileData)
+        , m_batchTable(metadata, tileData)
     { }
 
     std::vector<char> asBinary() const;

--- a/entwine/third/arbiter/arbiter.hpp
+++ b/entwine/third/arbiter/arbiter.hpp
@@ -1,7 +1,7 @@
 /// Arbiter amalgamated header (https://github.com/connormanning/arbiter).
 /// It is intended to be used with #include "arbiter.hpp"
 
-// Git SHA: e3fead2f855dc2d3193cd3bb784f7d90b5d5daff
+// Git SHA: d937cefcdc4ac6425835c842e1edc9d4c10f2ef5
 
 // //////////////////////////////////////////////////////////////////////
 // Beginning of content of file: LICENSE

--- a/entwine/tree/chunk.cpp
+++ b/entwine/tree/chunk.cpp
@@ -203,7 +203,7 @@ void SparseChunk::tile() const
         const std::size_t tick(tilePair.first);
         const auto& tileData(tilePair.second);
 
-        cesium::Tile tile(tileData);
+        cesium::Tile tile(m_metadata, tileData);
 
         io::ensurePut(
                 endpoint,
@@ -292,7 +292,7 @@ void ContiguousChunk::tile() const
         const std::size_t tick(tilePair.first);
         const auto& tileData(tilePair.second);
 
-        cesium::Tile tile(tileData);
+        cesium::Tile tile(m_metadata, tileData);
 
         io::ensurePut(
                 endpoint,

--- a/entwine/types/metadata.hpp
+++ b/entwine/types/metadata.hpp
@@ -17,6 +17,7 @@
 #include <pdal/Dimension.hpp>
 
 #include <entwine/types/bounds.hpp>
+#include <entwine/types/defs.hpp>
 #include <entwine/types/storage-types.hpp>
 
 namespace Json { class Value; }


### PR DESCRIPTION
I've completed a rudimentary implementation of cesium batch tables to copy dimensions to the batch table. It was based on the 1.2.0 release, because at this stage using the more recent code base is nigh on impossible on Windows. Hopefully the merge from my branch in master didn't break anything on that front because I can't build master. This might also fix #59 however the requirements for that issue weren't all that well defined.

The implementation has been tested with some fairly large datasets and seems to work fine without any significant overhead. Documentation is in the Cesium README.md.

The pull request also includes an updated Arbiter bundle for Windows functionality.

Let me know what you think. If there is anything wrong with it, I'm sure I can make changes where necessary.