### PR TITLE
Neaten up EPT source-file metadata information

### DIFF
--- a/app/build.cpp
+++ b/app/build.cpp
@@ -39,9 +39,9 @@ void Build::addArgs()
 
     addInput(
             "File paths or directory entries.  For a recursive directory "
-            "search, the notation is 'directory**'.  May also be the path "
-            "to an `entwine scan` output file\n"
-            "Example: --input path.laz, -i pointclouds/, -i scan.json");
+            "search, the notation is \"directory**\".  May also be the path "
+            "to an `entwine scan` output file.\n"
+            "Example: -i path.laz, -i pointclouds/, -i autzen/scan.json");
 
     addOutput(
             "Output directory.\n"
@@ -54,7 +54,7 @@ void Build::addArgs()
     m_ap.add(
             "--threads",
             "-t",
-            "The number of threads\n"
+            "The number of threads.\n"
             "Example: --threads 12",
             [this](Json::Value v) { m_json["threads"] = parse(v.asString()); });
 

--- a/app/entwine.cpp
+++ b/app/entwine.cpp
@@ -135,14 +135,6 @@ void App::addReprojection()
             "Example: --reprojection EPSG:3857, -r EPSG:26915 EPSG:3857",
             [this](Json::Value v)
             {
-            /*
-                if (!m_json.isMember("pipeline"))
-                {
-                    // Add a reader.
-                    m_json["pipeline"].append(Json::objectValue);
-                }
-                */
-
                 if (v.isString())
                 {
                     m_json["reprojection"]["out"] = v.asString();

--- a/app/scan.cpp
+++ b/app/scan.cpp
@@ -83,6 +83,7 @@ void Scan::run()
     std::cout << std::endl;
 
     std::cout << "Results:" << std::endl;
+    std::cout << "\tFiles: " << out.input().size() << std::endl;
     std::cout << "\tSchema: " << getDimensionString(schema) << std::endl;
     std::cout << "\tPoints: " << commify(out.points()) << std::endl;
     std::cout << "\tBounds: " << Bounds(out["bounds"]) << std::endl;

--- a/app/scan.cpp
+++ b/app/scan.cpp
@@ -97,7 +97,7 @@ void Scan::run()
     else std::cout << "(absolute)";
     std::cout << std::endl;
 
-    const double density(densityLowerBound(out.input()));
+    const double density(densityLowerBound(scan.files().list()));
     std::cout << "\tDensity estimate (per square unit): " << density <<
         std::endl;
 

--- a/entwine/builder/config.cpp
+++ b/entwine/builder/config.cpp
@@ -160,7 +160,7 @@ FileInfoList Config::input() const
         }
     });
 
-    const auto& i(m_json["input"]);
+    const Json::Value& i(m_json["input"]);
     if (i.isString()) insert(i);
     else if (i.isArray()) for (const auto& j : i) insert(j);
 
@@ -178,7 +178,7 @@ Json::Value Config::pipeline(std::string filename) const
     }
 
     Json::Value& reader(p[0]);
-    reader["filename"] = filename;
+    if (!filename.empty()) reader["filename"] = filename;
 
     if (r)
     {

--- a/entwine/builder/config.cpp
+++ b/entwine/builder/config.cpp
@@ -17,71 +17,108 @@
 namespace entwine
 {
 
+namespace
+{
+
+const std::string scanFile("scan.json");
+
+bool isScan(std::string s)
+{
+    return s.rfind(scanFile) == s.size() - scanFile.size();
+}
+
+} // unnamed namespace
+
+Config Config::fromScan(const std::string file) const
+{
+    if (verbose())
+    {
+        std::cout << "Using existing scan " << file << std::endl;
+    }
+
+    // First grab the configuration portion, which contains things like the
+    // pipeline/reprojection used to run this scan, and its results like the
+    // scale/schema/SRS/bounds.
+    arbiter::Arbiter a(m_json["arbiter"]);
+    Config c(entwine::parse(ensureGet(a, file)));
+
+    // Now we'll pluck out the file information.  Mirroring the EPT source
+    // metadata format, we have a sparse list at `ept-sources/list.json` which
+    // may point to more detailed metadata information.  Only the primary
+    // builder should wake up the detailed metadata to transit it to the final
+    // EPT output.
+    //
+    // The primary builder is a) the sole builder if this is not a subset build
+    // or b) the subset with ID 1.
+    const std::string dir(file.substr(0, file.rfind(scanFile)));
+    arbiter::Endpoint ep(a.getEndpoint(dir));
+
+    FileInfoList list(Files::extract(ep, primary()));
+    c["input"] = Files(list).toJson();
+
+    return c;
+}
+
 Config Config::prepare() const
 {
-    Json::Value input;
-    Json::Value scanDir;
-
-    // If our input is a Scan, extract it and return the result without redoing
-    // the scan.
     Json::Value from(m_json["input"]);
-
-    // Our kernel always builds the input as an array.
-    if (from.isArray() && from[0].isString()) from = from[0];
 
     // For a continuation build, we might just have an output.
     if (from.isNull()) return json();
 
+    // Make sure we have an array.
     if (from.isString())
     {
-        const std::string file(from.asString());
-        const std::string scanFile("ept-scan.json");
-        if (file.rfind(scanFile) == file.size() - scanFile.size())
-        {
-            if (verbose())
-            {
-                std::cout << "Using existing scan " << file << std::endl;
-            }
-
-            arbiter::Arbiter a(m_json["arbiter"]);
-            input = entwine::parse(ensureGet(a, file));
-            const std::string dir(file.substr(0, file.rfind(scanFile)));
-
-            scanDir = dir;
-        }
+        const Json::Value prev(from);
+        from = Json::arrayValue;
+        from.append(prev);
     }
 
-    if (input.isNull() && (!from.isObject() || (
-                from.isArray() && std::any_of(
+    if (!from.isArray())
+    {
+        throw std::runtime_error(
+                "Unexpected 'input': " + from.toStyledString());
+    }
+
+    Json::Value scan;
+
+    // If our input is a Scan, extract it without redoing the scan.
+    if (from.size() == 1 && isScan(from[0].asString()))
+    {
+        scan = fromScan(from[0].asString()).json();
+        from = scan["input"];
+    }
+
+    if (std::any_of(
                     from.begin(),
                     from.end(),
-                    [](Json::Value j) { return !j.isObject(); }))))
+                    [](Json::Value j) { return !j.isObject(); }))
     {
+        // TODO If this is a continued build with files added, we shouldn't be
+        // re-scanning everything.  This should be filtered by only the entries
+        // which are not objects and then the result intelligently merged.
         if (verbose()) std::cout << "Scanning input" << std::endl;
 
         // Remove the output from the Scan config - this path is the output
         // path for the subsequent 'build' step.
         Json::Value scanConfig(json());
         scanConfig.removeMember("output");
-        Scan scan(scanConfig);
-        Config config(scan.go());
-        input = config.json();
+        scan = Scan(scanConfig).go().json();
     }
 
     // First, soft-merge our scan results over the config without overwriting
     // anything, for example we might have an explicit scale factor or bounds
     // specification that should override scan results.
-    Json::Value result = merge(json(), input, false);
+    Json::Value result = merge(json(), scan, false);
+
+    // If we've just completed a scan or extracted an existing scan, make sure
+    // our input represents the scanned data rather than raw paths.
+    if (!scan.isNull()) result["input"] = scan["input"];
 
     // If our input SRS existed, we might potentially overwrite missing fields
     // there with ones we've found from the scan.  Vertical EPSG code, for
     // example.  In this case accept the input without merging.
     if (json().isMember("srs")) result["srs"] = json()["srs"];
-
-    // Then, always make sure we use the "input" from the scan, which
-    // represents the expanded input files and their meta-info rather than the
-    // path of the scan or the string paths.
-    if (!input.isNull()) result["input"] = input["input"];
 
     // Prepare the schema, adding OriginId and determining a proper offset, if
     // necessary.
@@ -113,7 +150,6 @@ Config Config::prepare() const
     }
 
     result["schema"] = s.toJson();
-    result["scanDir"] = scanDir;
 
     return result;
 }

--- a/entwine/builder/config.hpp
+++ b/entwine/builder/config.hpp
@@ -42,6 +42,10 @@ public:
         : m_json(json)
     { }
 
+    // Used by the builder to normalize the input, this utility ensures:
+    //      - Input data is scanned prior to input.
+    //      - If the input is already a scan, that the scan is parsed properly
+    //        and has its configuration merged in.
     Config prepare() const;
 
     static Json::Value defaults()
@@ -73,6 +77,7 @@ public:
     Json::Value pipeline(std::string filename) const;
 
     FileInfoList input() const;
+
     std::string output() const { return m_json["output"].asString(); }
     std::string tmp() const { return m_json["tmp"].asString(); }
 
@@ -178,7 +183,7 @@ public:
 
     std::string postfix() const
     {
-        if (!m_json["subset"].isNull())
+        if (m_json.isMember("subset"))
         {
             return "-" + std::to_string(m_json["subset"]["id"].asUInt64());
         }
@@ -200,6 +205,14 @@ public:
     }
 
 private:
+    bool primary() const
+    {
+        return !m_json.isMember("subset") ||
+            m_json["subset"]["id"].asUInt64() == 1;
+    }
+
+    Config fromScan(std::string file) const;
+
     Json::Value m_json;
 };
 

--- a/entwine/builder/scan.cpp
+++ b/entwine/builder/scan.cpp
@@ -93,7 +93,9 @@ Config Scan::go()
         }
 
         m_files.save(ep, "", m_in, true);
-        ep.put("ept-scan.json", toPreciseString(out.json(), true));
+        Json::Value json(out.json());
+        json.removeMember("input");
+        ep.put("scan.json", toPreciseString(json, true));
 
         if (m_in.verbose())
         {
@@ -240,6 +242,7 @@ Config Scan::aggregate()
 
     if (out["schema"].isNull()) out["schema"] = m_schema.toJson();
     out["points"] = std::max<Json::UInt64>(np, out.points());
+    out["input"] = m_files.toJson();
     if (m_re) out["reprojection"] = m_re->toJson();
     out["srs"] = srs.toJson();
     out["pipeline"] = m_in.pipeline("");

--- a/entwine/builder/scan.cpp
+++ b/entwine/builder/scan.cpp
@@ -79,6 +79,11 @@ Config Scan::go()
             {
                 std::cout << "Could not mkdir: " << path << std::endl;
             }
+
+            if (!arbiter::fs::mkdirp(ep.getSubEndpoint("ept-sources").root()))
+            {
+                std::cout << "Could not mkdir: " << path << std::endl;
+            }
         }
 
         if (m_in.verbose())
@@ -87,11 +92,8 @@ Config Scan::go()
             std::cout << "Writing details to " << path << "..." << std::flush;
         }
 
-        m_files.writeSources(ep, m_in);
-        out["input"] = Files(out["input"]).toPrivateJson();
-
-        const std::string filename("ept-scan.json");
-        ep.put(filename, toPreciseString(out.json(), m_files.size() <= 100));
+        m_files.save(ep, "", m_in, true);
+        ep.put("ept-scan.json", toPreciseString(out.json(), true));
 
         if (m_in.verbose())
         {
@@ -238,10 +240,9 @@ Config Scan::aggregate()
 
     if (out["schema"].isNull()) out["schema"] = m_schema.toJson();
     out["points"] = std::max<Json::UInt64>(np, out.points());
-    out["input"] = m_files.toSourcesJson();
     if (m_re) out["reprojection"] = m_re->toJson();
     out["srs"] = srs.toJson();
-    out["pipeline"] = m_in.pipeline("...");
+    out["pipeline"] = m_in.pipeline("");
 
     return out;
 }

--- a/entwine/types/bounds.hpp
+++ b/entwine/types/bounds.hpp
@@ -101,7 +101,7 @@ public:
     double width()  const { return m_max.x - m_min.x; } // Length in X.
     double depth()  const { return m_max.y - m_min.y; } // Length in Y.
     double height() const { return m_max.z - m_min.z; } // Length in Z.
-    explicit operator bool() const { return width() && depth() && height(); }
+    explicit operator bool() const { return exists(); }
 
     double area() const { return width() * depth(); }
     double volume() const { return width() * depth() * height(); }

--- a/entwine/types/file-info.cpp
+++ b/entwine/types/file-info.cpp
@@ -53,19 +53,17 @@ FileInfo::FileInfo(const Json::Value& json)
 {
     if (!json.isObject()) return;
 
-    if (json.isMember("status"))
-    {
-        m_status = toStatus(json["status"].asString());
-    }
+    if (json.isMember("id")) m_id = json["id"].asString();
+    if (json.isMember("status")) m_status = toStatus(json["status"].asString());
 
     m_points = json["points"].asUInt64();
-
     if (m_points && json.isMember("bounds"))
     {
         m_bounds = Bounds(json["bounds"]);
         m_boundsEpsilon = m_bounds.growBy(0.005);
     }
 
+    m_url = json["url"].asString();
     m_metadata = json["metadata"];
     m_pointStats = PointStats(
             json["inserts"].asUInt64(),

--- a/entwine/types/file-info.hpp
+++ b/entwine/types/file-info.hpp
@@ -93,6 +93,11 @@ public:
 
     void add(const PointStats& stats) { m_pointStats.add(stats); }
 
+    Json::Value toJson() const
+    {
+        return merge(toListJson(), toFullJson());
+    }
+
 private:
     void setId(std::string id) const { m_id = id; }
     void setUrl(std::string url) const { m_url = url; }

--- a/entwine/types/files.cpp
+++ b/entwine/types/files.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <iostream>
 #include <limits>
+#include <set>
 
 #include <entwine/io/ensure.hpp>
 #include <entwine/types/bounds.hpp>
@@ -24,90 +25,105 @@
 namespace entwine
 {
 
-Json::Value Files::toPrivateJson() const
+namespace
 {
-    Json::Value json;
-    for (const FileInfo& f : list()) json.append(f.toPrivateJson());
-    return json;
+
+std::string idFrom(std::string path)
+{
+    return arbiter::util::getBasename(path);
 }
 
-Json::Value Files::toSourcesJson() const
+} // unnamed namespace
+
+Files::Files(const FileInfoList& files)
+    : m_files(files)
 {
-    Json::Value json;
-    for (const FileInfo& f : list()) json.append(f.toSourcesJson());
-    return json;
+    // Aggregate statuses.
+    for (const auto& f : m_files)
+    {
+        m_pointStats += f.pointStats();
+        addStatus(f.status());
+    }
+
+    // Initialize origin info for detailed metadata storage purposes.
+    for (uint64_t i(0); i < m_files.size(); ++i)
+    {
+        m_files[i].setOrigin(i);
+    }
+
+    // If the basenames of all files are unique amongst one-another, then use
+    // the basename as the ID for detailed metadata storage.  Otherwise use the
+    // full file path.
+    const uint64_t sourcesStep(100);
+
+    bool unique(true);
+    std::set<std::string> basenames;
+    for (const FileInfo& f : list())
+    {
+        const auto id(idFrom(f.path()));
+        if (basenames.count(id))
+        {
+            unique = false;
+            break;
+        }
+        else basenames.insert(id);
+    }
+
+    if (unique)
+    {
+        for (uint64_t i(0); i < m_files.size(); ++i)
+        {
+            const FileInfo& f(m_files[i]);
+            f.setId(idFrom(f.path()));
+            f.setUrl(std::to_string(i / sourcesStep * sourcesStep) +
+                    ".json");
+        }
+    }
 }
 
 void Files::save(
-        const arbiter::Endpoint& ep,
+        const arbiter::Endpoint& top,
         const std::string& postfix,
         const Config& config,
         const bool detailed) const
 {
-    writePrivate(ep, postfix);
-
-    if (detailed)
-    {
-        writeSources(ep.getSubEndpoint("ept-sources"), postfix, config);
-    }
+    const auto ep(top.getSubEndpoint("ept-sources"));
+    writeList(ep, postfix);
+    if (detailed) writeFull(ep, config);
 }
 
-void Files::writePrivate(
+void Files::writeList(
         const arbiter::Endpoint& ep,
         const std::string& postfix) const
 {
     Json::Value json;
-    for (const FileInfo& f : list()) json.append(f.toPrivateJson());
+    for (const FileInfo& f : list()) json.append(f.toListJson());
 
-    const std::string filename("ept-sources/list" + postfix + ".json");
     const bool styled(size() <= 1000);
-    ensurePut(ep, filename, toPreciseString(json, styled));
+    ensurePut(ep, "list" + postfix + ".json", toPreciseString(json, styled));
 }
 
-void Files::writeSources(const arbiter::Endpoint& out, const Config& config)
-    const
-{
-    writeSources(out, "", config);
-}
-
-void Files::writeSources(
-        const arbiter::Endpoint& out,
-        const std::string& postfix,
+void Files::writeFull(
+        const arbiter::Endpoint& ep,
         const Config& config) const
 {
-    arbiter::Arbiter a(config["arbiter"]);
-    std::unique_ptr<arbiter::Endpoint> scanEp;
-    if (config["scanDir"].isString())
-    {
-        scanEp = makeUnique<arbiter::Endpoint>(
-                a.getEndpoint(config["scanDir"].asString()));
-
-        if (config.verbose())
-        {
-            std::cout << "Copying metadata from scan at " << scanEp->root() <<
-                std::endl;
-        }
-    }
-
     Pool pool(config.totalThreads());
 
-    const bool styled(size() <= 1000);
-    for (Origin o(0); o < size(); ++o)
+    std::map<std::string, Json::Value> meta;
+    for (const auto& f : m_files)
     {
-        if (config.verbose() && o % 1000 == 0)
+        meta[f.url()][f.id()] = f.toFullJson();
+    }
+
+    const bool styled(size() <= 1000);
+
+    for (const auto& p : meta)
+    {
+        pool.add([this, &ep, &p, styled]()
         {
-            std::cout << o << " / " << size() << std::endl;
-        }
-
-        pool.add([this, &scanEp, &out, styled, o]()
-        {
-            const std::string filename(std::to_string(o) + ".json");
-
-            Json::Value json;
-            if (scanEp) json = parse(scanEp->get(filename));
-            json = entwine::merge(json, get(o).toSourcesJson());
-
-            ensurePut(out, filename, toPreciseString(json, styled));
+            const std::string& filename(p.first);
+            const Json::Value& json(p.second);
+            ensurePut(ep, filename, toPreciseString(json, styled));
         });
     }
 
@@ -145,7 +161,7 @@ void Files::merge(const Files& other)
 
     for (std::size_t i(0); i < size(); ++i)
     {
-        m_files[i].merge(other.list()[i]);
+        m_files[i].add(other.list()[i]);
     }
 }
 

--- a/entwine/types/files.hpp
+++ b/entwine/types/files.hpp
@@ -37,6 +37,11 @@ public:
     Files(const FileInfoList& files);
     Files(const Json::Value& json) : Files(toFileInfo(json)) { }
 
+    static FileInfoList extract(
+            const arbiter::Endpoint& ep,
+            bool primary,
+            std::string postfix = "");
+
     void save(
             const arbiter::Endpoint& ep,
             const std::string& postfix,
@@ -107,6 +112,16 @@ public:
     }
 
     void merge(const Files& other);
+
+    Json::Value toJson() const
+    {
+        Json::Value json;
+        for (const auto& f : list())
+        {
+            json.append(f.toJson());
+        }
+        return json;
+    }
 
 private:
     void writeList(const arbiter::Endpoint& ep, const std::string& postfix)

--- a/entwine/types/files.hpp
+++ b/entwine/types/files.hpp
@@ -34,20 +34,8 @@ class Pool;
 class Files
 {
 public:
-    Files(const FileInfoList& files)
-        : m_files(files)
-    {
-        for (const auto& f : m_files)
-        {
-            m_pointStats += f.pointStats();
-            addStatus(f.status());
-        }
-    }
-
+    Files(const FileInfoList& files);
     Files(const Json::Value& json) : Files(toFileInfo(json)) { }
-
-    Json::Value toPrivateJson() const;
-    Json::Value toSourcesJson() const;
 
     void save(
             const arbiter::Endpoint& ep,
@@ -120,24 +108,11 @@ public:
 
     void merge(const Files& other);
 
-
-    // Write per-file detailed metadata.  This might need to be copied from an
-    // input scan location, or might be in-process for a build from a file
-    // input list.  It could also be a combination of both for continued builds.
-    void writeSources(const arbiter::Endpoint& ep, const Config& config) const;
-
 private:
-    // Write a single file with our private indexing metadata.
-    void writePrivate(const arbiter::Endpoint& ep, const std::string& postfix)
+    void writeList(const arbiter::Endpoint& ep, const std::string& postfix)
         const;
 
-    // Write per-file detailed metadata.  This might need to be copied from an
-    // input scan location, or might be in-process for a build from a file
-    // input list.  It could also be a combination of both for continued builds.
-    void writeSources(
-            const arbiter::Endpoint& ep,
-            const std::string& postfix,
-            const Config& config) const;
+    void writeFull(const arbiter::Endpoint& ep, const Config& config) const;
 
     void addStatus(FileInfo::Status status)
     {

--- a/entwine/types/metadata.cpp
+++ b/entwine/types/metadata.cpp
@@ -101,7 +101,7 @@ Metadata::Metadata(const arbiter::Endpoint& ep, const Config& config)
                     parse(ep.get("ept-build" + config.postfix() + ".json")))),
             true)
 {
-    Files files(parse(ep.get("ept-sources/list" + postfix() + ".json")));
+    Files files(Files::extract(ep, primary(), config.postfix()));
     files.append(m_files->list());
     m_files = makeUnique<Files>(files.list());
 }

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM connormanning/pdal
+FROM connormanning/pdal:master
 MAINTAINER Connor Manning <connor@hobu.co>
 
 RUN apt-get update && apt-get install -y \
@@ -7,9 +7,8 @@ RUN apt-get update && apt-get install -y \
     git \
     liblzma-dev \
     libjsoncpp-dev \
-    libcurl4-openssl-dev \
-    curl \
     libssl-dev \
+    libcurl4-openssl-dev \
     python-numpy \
     python-pip \
     vim && \

--- a/test/unit/build.cpp
+++ b/test/unit/build.cpp
@@ -13,6 +13,34 @@ namespace
 {
     const arbiter::Arbiter a;
     const Verify v;
+
+    void checkSources(std::string outPath)
+    {
+        const auto list(parse(a.get(outPath + "ept-sources/list.json")));
+        EXPECT_EQ(list.size(), 8u);
+
+        for (Json::ArrayIndex o(0); o < 8; ++o)
+        {
+            const auto entry(list[o]);
+            const auto id(entry["id"].asString());
+            const auto url(entry["url"].asString());
+            const Bounds bounds(entry["bounds"]);
+
+            ASSERT_TRUE(bounds.exists());
+            ASSERT_GT(id.size(), 0);
+            ASSERT_GT(url.size(), 0);
+
+            const auto full(parse(a.get(outPath + "ept-sources/" + url)));
+            ASSERT_FALSE(full.isNull());
+            ASSERT_TRUE(full.isMember(id));
+
+            const auto meta(full[id]);
+            ASSERT_FALSE(meta.isNull());
+            ASSERT_GT(meta["points"].asUInt64(), 0u);
+            ASSERT_EQ(meta["origin"].asUInt64(), (Origin)o);
+            ASSERT_TRUE(meta["metadata"].isObject());
+        }
+    }
 }
 
 TEST(build, basic)
@@ -57,15 +85,7 @@ TEST(build, basic)
 
     EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
 
-    EXPECT_EQ(parse(a.get(outPath + "ept-sources/list.json")).size(), 8u);
-
-    for (Json::ArrayIndex o(0); o < 8; ++o)
-    {
-        const auto path(metaPath + std::to_string(o) + ".json");
-        const auto meta(parse(a.get(path)));
-        ASSERT_FALSE(meta.isNull());
-        ASSERT_GT(meta["points"].asUInt64(), 0u);
-    }
+    checkSources(outPath);
 }
 
 TEST(build, continued)
@@ -120,15 +140,7 @@ TEST(build, continued)
 
     EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
 
-    EXPECT_EQ(parse(a.get(outPath + "ept-sources/list.json")).size(), 8u);
-
-    for (Json::ArrayIndex o(0); o < 8; ++o)
-    {
-        const auto path(metaPath + std::to_string(o) + ".json");
-        const auto meta(parse(a.get(path)));
-        ASSERT_FALSE(meta.isNull());
-        ASSERT_GT(meta["points"].asUInt64(), 0u);
-    }
+    checkSources(outPath);
 }
 
 TEST(build, fromScan)
@@ -148,7 +160,7 @@ TEST(build, fromScan)
     const std::string metaPath(outPath + "ept-sources/");
 
     Config c;
-    c["input"] = scanPath + "ept-scan.json";
+    c["input"] = scanPath + "scan.json";
     c["output"] = outPath;
     c["force"] = true;
     c["ticks"] = static_cast<Json::UInt64>(v.ticks());
@@ -184,15 +196,7 @@ TEST(build, fromScan)
 
     EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
 
-    EXPECT_EQ(parse(a.get(outPath + "ept-sources/list.json")).size(), 8u);
-
-    for (Json::ArrayIndex o(0); o < 8; ++o)
-    {
-        const auto path(metaPath + std::to_string(o) + ".json");
-        const auto meta(parse(a.get(path)));
-        ASSERT_FALSE(meta.isNull());
-        ASSERT_GT(meta["points"].asUInt64(), 0u);
-    }
+    checkSources(outPath);
 }
 
 TEST(build, subset)
@@ -249,15 +253,7 @@ TEST(build, subset)
 
     EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
 
-    EXPECT_EQ(parse(a.get(outPath + "ept-sources/list.json")).size(), 8u);
-
-    for (Json::ArrayIndex o(0); o < 8; ++o)
-    {
-        const auto path(metaPath + std::to_string(o) + ".json");
-        const auto meta(parse(a.get(path)));
-        ASSERT_FALSE(meta.isNull());
-        ASSERT_GT(meta["points"].asUInt64(), 0u);
-    }
+    checkSources(outPath);
 }
 
 TEST(build, invalidSubset)
@@ -318,7 +314,7 @@ TEST(build, subsetFromScan)
     for (Json::UInt64 i(0); i < 4u; ++i)
     {
         Config c;
-        c["input"] = scanPath + "ept-scan.json";
+        c["input"] = scanPath + "scan.json";
         c["output"] = outPath;
         c["force"] = true;
         c["ticks"] = static_cast<Json::UInt64>(v.ticks());
@@ -364,15 +360,7 @@ TEST(build, subsetFromScan)
 
     EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
 
-    EXPECT_EQ(parse(a.get(outPath + "ept-sources/list.json")).size(), 8u);
-
-    for (Json::ArrayIndex o(0); o < 8; ++o)
-    {
-        const auto path(metaPath + std::to_string(o) + ".json");
-        const auto meta(parse(a.get(path)));
-        ASSERT_FALSE(meta.isNull());
-        ASSERT_GT(meta["points"].asUInt64(), 0u);
-    }
+    checkSources(outPath);
 }
 
 TEST(build, reprojected)
@@ -419,14 +407,6 @@ TEST(build, reprojected)
 
     EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
 
-    EXPECT_EQ(parse(a.get(outPath + "ept-sources/list.json")).size(), 8u);
-
-    for (Json::ArrayIndex o(0); o < 8; ++o)
-    {
-        const auto path(metaPath + std::to_string(o) + ".json");
-        const auto meta(parse(a.get(path)));
-        ASSERT_FALSE(meta.isNull());
-        ASSERT_GT(meta["points"].asUInt64(), 0u);
-    }
+    checkSources(outPath);
 }
 

--- a/test/unit/scan.cpp
+++ b/test/unit/scan.cpp
@@ -253,7 +253,7 @@ TEST(scan, outputFile)
     in["input"] = test::dataPath() + "ellipsoid.laz";
     in["output"] = test::dataPath() + "out/scan/";
     Scan(in).go();
-    const std::string path(test::dataPath() + "out/scan/ept-scan.json");
+    const std::string path(test::dataPath() + "out/scan/scan.json");
     const Config out(parse(arbiter::Arbiter().get(path)));
     ASSERT_FALSE(out.json().isNull());
 
@@ -264,10 +264,15 @@ TEST(scan, outputFile)
     EXPECT_EQ(out.points(), v.points());
     ASSERT_EQ(schema, v.schema());
 
-    const FileInfoList input(out.input());
-    ASSERT_EQ(input.size(), 1u);
+    // File information is stored in ept-sources, not the top-level scan JSON.
+    EXPECT_TRUE(out.json()["input"].isNull());
 
-    const FileInfo file(input.at(0));
+    arbiter::Arbiter a;
+    auto ep(a.getEndpoint(test::dataPath() + "out/scan/"));
+    const FileInfoList files(Files::extract(ep, true));
+    ASSERT_EQ(files.size(), 1u);
+
+    const FileInfo file(files.at(0));
     const auto expFile(Executor::get().preview(file.path()));
     ASSERT_TRUE(expFile);
 


### PR DESCRIPTION
Neaten up the storage of EPT source file metadata.  See #128.  Updated documentation for this portion of the format can be seen [here](https://github.com/connormanning/entwine/blob/d62c7e8806062b01d46eb3d2e198f0b248354107/doc/entwine-point-tile.md#ept-sources).  This update removes some redundant information, makes some implicit metadata ties explicit, and makes the storage format of source-file metadata more configurable/chunkable rather than requiring an entry per file.