### PR TITLE
Correct byte padding for Cesium 3D Tiles to support Batch Table

### DIFF
--- a/entwine/formats/cesium/batch-table.cpp
+++ b/entwine/formats/cesium/batch-table.cpp
@@ -77,11 +77,25 @@ Json::Value BatchTable::getJson() const
 void BatchTable::appendBinary(std::vector<char>& data) const
 {
     data.insert(data.end(), m_data.begin(), m_data.end());
+
+    // Pad remaining space so that batch table will end at 8-byte boundary
+    if (m_data.size() % 8)
+    {
+        data.insert(data.end(), 8 - (m_data.size() % 8), 'X');
+    }
 }
 
 std::size_t BatchTable::bytes() const
 {
-    return m_data.size();
+    std::size_t size = m_data.size();
+
+    // Reserve extra bytes for padding to 8-byte boundary
+    if (size % 8)
+    {
+        size += 8 - (size % 8);
+    }
+
+    return size;
 }
 
 const std::vector<Point>& BatchTable::points() const


### PR DESCRIPTION
3D Tiles generated with Entwine 1.3.0 don't include the byte padding for Feature and Batch Tables (see [Point Cloud Tile Format Spec](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/specification/TileFormats/PointCloud/README.md#padding)) and therefore Cesium can fail loading 3D Tiles with a Batch Table.

This pull request contains a patch that will pad those binary file sections to the required 8-byte boundary. Furthermore, it can resolve https://github.com/connormanning/entwine/issues/118.