### PR TITLE
Rename 'ticks' to 'span'.

### DIFF
--- a/app/build.cpp
+++ b/app/build.cpp
@@ -73,12 +73,12 @@ void Build::addArgs()
             [this](Json::Value v) { m_json["dataType"] = v.asString(); });
 
     m_ap.add(
-            "--ticks",
+            "--span",
             "Number of voxels in each spatial dimension for data nodes.  "
-            "For example, a ticks setting of 256 will result in a cube of "
-            "256*256*256 resolution.  Default: 256.\n"
-            "Example: --ticks 128",
-            [this](Json::Value v) { m_json["ticks"] = extract(v); });
+            "For example, a span of 256 will result in a cube of 256*256*256 "
+            "resolution.  Default: 256.\n"
+            "Example: --span 128",
+            [this](Json::Value v) { m_json["span"] = extract(v); });
 
     m_ap.add(
             "--noOriginId",
@@ -331,9 +331,9 @@ void Build::log(const Builder& b) const
             (reprojection ? reprojection->toString() : "(none)") << "\n" <<
         "\tStoring dimensions: " << getDimensionString(schema) << std::endl;
 
-    const auto t(metadata.ticks());
+    const auto t(metadata.span());
     std::cout << "Build parameters:\n" <<
-        "\tTicks: " << t << "\n" <<
+        "\tSpan: " << t << "\n" <<
         "\tResolution 2D: " <<
             t << " * " << t << " = " << commify(t * t) << "\n" <<
         "\tResolution 3D: " <<

--- a/entwine/builder/chunk.hpp
+++ b/entwine/builder/chunk.hpp
@@ -86,7 +86,7 @@ class Chunk
 public:
     Chunk(const ReffedChunk& ref)
         : m_ref(ref)
-        , m_ticks(m_ref.metadata().ticks())
+        , m_span(m_ref.metadata().span())
         , m_pointSize(m_ref.metadata().schema().pointSize())
         , m_gridBlock(m_pointSize, 4096)
         , m_overflowBlock(m_pointSize, 1024)
@@ -110,7 +110,7 @@ public:
     void init()
     {
         assert(!m_grid);
-        m_grid = makeUnique<std::vector<VoxelTube>>(m_ticks * m_ticks);
+        m_grid = makeUnique<std::vector<VoxelTube>>(m_span * m_span);
         assert(!m_overflow);
         m_overflow = makeUnique<std::vector<Overflow>>();
         m_remote = false;
@@ -145,7 +145,7 @@ public:
     bool insert(Voxel& voxel, Key& key, Clipper& clipper)
     {
         const Xyz& pos(key.position());
-        const std::size_t i((pos.y % m_ticks) * m_ticks + (pos.x % m_ticks));
+        const std::size_t i((pos.y % m_span) * m_span + (pos.x % m_span));
         VoxelTube& tube((*m_grid)[i]);
 
         UniqueSpin tubeLock(tube.spin);
@@ -235,7 +235,7 @@ private:
     }
 
     const ReffedChunk& m_ref;
-    const uint64_t m_ticks;
+    const uint64_t m_span;
     const uint64_t m_pointSize;
     bool m_remote = false;
 

--- a/entwine/builder/config.hpp
+++ b/entwine/builder/config.hpp
@@ -67,7 +67,7 @@ public:
         json["dataType"] = "laszip";
         json["hierarchyType"] = "json";
 
-        json["ticks"] = 256;
+        json["span"] = 256;
         json["overflowDepth"] = 0;
         json["overflowRatio"] = 0.5;
 
@@ -152,7 +152,7 @@ public:
             m_json["allowOriginId"].asBool();
     }
 
-    uint64_t ticks() const { return m_json["ticks"].asUInt64(); }
+    uint64_t span() const { return m_json["span"].asUInt64(); }
 
     uint64_t overflowDepth() const
     {
@@ -167,7 +167,7 @@ public:
         }
         else
         {
-            return ticks() * ticks() * m_json["overflowRatio"].asDouble();
+            return span() * span() * m_json["overflowRatio"].asDouble();
         }
     }
     uint64_t hierarchyStep() const

--- a/entwine/types/metadata.cpp
+++ b/entwine/types/metadata.cpp
@@ -43,15 +43,15 @@ Metadata::Metadata(const Config& config, const bool exists)
     , m_srs(makeUnique<Srs>(config.srs()))
     , m_subset(Subset::create(*this, config["subset"]))
     , m_trustHeaders(config.trustHeaders())
-    , m_ticks(config.ticks())
-    , m_startDepth(std::log2(m_ticks))
+    , m_span(config.span())
+    , m_startDepth(std::log2(m_span))
     , m_sharedDepth(m_subset ? m_subset->splits() : 0)
     , m_overflowDepth(std::max(config.overflowDepth(), m_sharedDepth))
     , m_overflowThreshold(config.overflowThreshold())
 {
-    if (1ULL << m_startDepth != m_ticks)
+    if (1ULL << m_startDepth != m_span)
     {
-        throw std::runtime_error("Invalid ticks");
+        throw std::runtime_error("Invalid voxel span");
     }
 
     if (m_outSchema->isScaled())
@@ -116,7 +116,7 @@ Json::Value Metadata::toJson() const
     json["bounds"] = boundsCubic().toJson();
     json["boundsConforming"] = boundsConforming().toJson();
     json["schema"] = m_outSchema->toJson();
-    json["ticks"] = (Json::UInt64)m_ticks;
+    json["span"] = (Json::UInt64)m_span;
     json["points"] = (Json::UInt64)m_files->totalInserts();
     json["dataType"] = m_dataIo->type();
     json["hierarchyType"] = "json"; // TODO.

--- a/entwine/types/metadata.hpp
+++ b/entwine/types/metadata.hpp
@@ -75,7 +75,7 @@ public:
     bool trustHeaders() const { return m_trustHeaders; }
     bool primary() const { return !m_subset || m_subset->primary(); }
 
-    uint64_t ticks() const { return m_ticks; }
+    uint64_t span() const { return m_span; }
     uint64_t startDepth() const { return m_startDepth; }
     uint64_t sharedDepth() const { return m_sharedDepth; }
     uint64_t overflowDepth() const { return m_overflowDepth; }
@@ -113,7 +113,7 @@ private:
 
     const bool m_trustHeaders = true;
 
-    const uint64_t m_ticks;
+    const uint64_t m_span;
     const uint64_t m_startDepth;
     const uint64_t m_sharedDepth;
 

--- a/test/unit/build.cpp
+++ b/test/unit/build.cpp
@@ -51,7 +51,7 @@ TEST(build, basic)
     c["input"] = test::dataPath() + "ellipsoid-multi/";
     c["output"] = outPath;
     c["force"] = true;
-    c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+    c["span"] = static_cast<Json::UInt64>(v.span());
     c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
 
     Builder(c).go();
@@ -82,7 +82,7 @@ TEST(build, basic)
     verifySchema.setOffset(bounds.mid().round());
     EXPECT_EQ(schema, verifySchema);
 
-    EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
+    EXPECT_EQ(info["span"].asUInt64(), v.span());
 
     checkSources(outPath);
 }
@@ -97,7 +97,7 @@ TEST(build, continued)
         c["input"] = test::dataPath() + "ellipsoid-multi/";
         c["output"] = outPath;
         c["force"] = true;
-        c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+        c["span"] = static_cast<Json::UInt64>(v.span());
         c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
         c["run"] = 4;
 
@@ -137,7 +137,7 @@ TEST(build, continued)
     verifySchema.setOffset(bounds.mid().round());
     EXPECT_EQ(schema, verifySchema);
 
-    EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
+    EXPECT_EQ(info["span"].asUInt64(), v.span());
 
     checkSources(outPath);
 }
@@ -162,7 +162,7 @@ TEST(build, fromScan)
     c["input"] = scanPath + "scan.json";
     c["output"] = outPath;
     c["force"] = true;
-    c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+    c["span"] = static_cast<Json::UInt64>(v.span());
     c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
 
     Builder(c).go();
@@ -193,7 +193,7 @@ TEST(build, fromScan)
     verifySchema.setOffset(bounds.mid().round());
     EXPECT_EQ(schema, verifySchema);
 
-    EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
+    EXPECT_EQ(info["span"].asUInt64(), v.span());
 
     checkSources(outPath);
 }
@@ -209,7 +209,7 @@ TEST(build, subset)
         c["input"] = test::dataPath() + "ellipsoid-multi/";
         c["output"] = outPath;
         c["force"] = true;
-        c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+        c["span"] = static_cast<Json::UInt64>(v.span());
         c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
         c["subset"]["id"] = i + 1u;
         c["subset"]["of"] = 4u;
@@ -250,7 +250,7 @@ TEST(build, subset)
     verifySchema.setOffset(bounds.mid().round());
     EXPECT_EQ(schema, verifySchema);
 
-    EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
+    EXPECT_EQ(info["span"].asUInt64(), v.span());
 
     checkSources(outPath);
 }
@@ -263,7 +263,7 @@ TEST(build, invalidSubset)
     c["input"] = test::dataPath() + "ellipsoid-multi/";
     c["output"] = outPath;
     c["force"] = true;
-    c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+    c["span"] = static_cast<Json::UInt64>(v.span());
     c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
     c["subset"]["id"] = 1;
 
@@ -316,7 +316,7 @@ TEST(build, subsetFromScan)
         c["input"] = scanPath + "scan.json";
         c["output"] = outPath;
         c["force"] = true;
-        c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+        c["span"] = static_cast<Json::UInt64>(v.span());
         c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
         c["subset"]["id"] = i + 1u;
         c["subset"]["of"] = 4u;
@@ -357,7 +357,7 @@ TEST(build, subsetFromScan)
     verifySchema.setOffset(bounds.mid().round());
     EXPECT_EQ(schema, verifySchema);
 
-    EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
+    EXPECT_EQ(info["span"].asUInt64(), v.span());
 
     checkSources(outPath);
 }
@@ -372,7 +372,7 @@ TEST(build, reprojected)
     c["output"] = outPath;
     c["reprojection"]["out"] = "EPSG:26918";
     c["force"] = true;
-    c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+    c["span"] = static_cast<Json::UInt64>(v.span());
     c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
 
     Builder(c).go();
@@ -404,7 +404,7 @@ TEST(build, reprojected)
     verifySchema.setOffset(bounds.mid().round());
     EXPECT_EQ(schema, verifySchema);
 
-    EXPECT_EQ(info["ticks"].asUInt64(), v.ticks());
+    EXPECT_EQ(info["span"].asUInt64(), v.span());
 
     checkSources(outPath);
 }

--- a/test/unit/read.cpp
+++ b/test/unit/read.cpp
@@ -21,7 +21,7 @@ TEST(read, count)
         c["output"] = out;
         c["force"] = true;
         c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
-        c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+        c["span"] = static_cast<Json::UInt64>(v.span());
 
         Builder b(c);
         b.go();
@@ -29,7 +29,7 @@ TEST(read, count)
 
     Reader r(out);
     const Metadata& m(r.metadata());
-    EXPECT_EQ(m.ticks(), v.ticks());
+    EXPECT_EQ(m.span(), v.span());
 
     uint64_t np(0);
     for (std::size_t i(0); i < 8; ++i)
@@ -55,7 +55,7 @@ TEST(read, data)
         c["output"] = out;
         c["force"] = true;
         c["hierarchyStep"] = static_cast<Json::UInt64>(v.hierarchyStep());
-        c["ticks"] = static_cast<Json::UInt64>(v.ticks());
+        c["span"] = static_cast<Json::UInt64>(v.span());
 
         Builder b(c);
         b.go();
@@ -63,7 +63,7 @@ TEST(read, data)
 
     Reader r(out);
     const Metadata& m(r.metadata());
-    EXPECT_EQ(m.ticks(), v.ticks());
+    EXPECT_EQ(m.span(), v.span());
 
     const Schema schema(DimList { DimId::X, DimId::Y, DimId::Z });
 

--- a/test/unit/verify.hpp
+++ b/test/unit/verify.hpp
@@ -44,6 +44,6 @@ public:
 
     uint64_t points() const { return 100000; }
     uint64_t hierarchyStep() const { return 2; }
-    uint64_t ticks() const { return 32; }
+    uint64_t span() const { return 32; }
 };
 


### PR DESCRIPTION
The name `ticks` has no obvious meaning without context and it's been asked about a number of times.  Docs have been updated accordingly, and also added documentation for the requirement of `span` to be a power of 2.

Barring any last-minute EPT-format discussion from the community, this will be the final format change and the current iteration of the EPT format will be have its first release in a few days.  Correspondingly the Entwine software will be released as 2.0 due to incompatibility with the pre-EPT 1.x versions.