### PR TITLE
Added required parameter to removeValue method

### DIFF
--- a/entwine/builder/config.cpp
+++ b/entwine/builder/config.cpp
@@ -102,7 +102,8 @@ Config Config::prepare() const
         // Remove the output from the Scan config - this path is the output
         // path for the subsequent 'build' step.
         Json::Value scanConfig(json());
-        scanConfig.removeMember("output");
+        Json::Value removed;
+        scanConfig.removeMember("output",&removed);
         scan = Scan(scanConfig).go().json();
     }
 

--- a/entwine/builder/scan.cpp
+++ b/entwine/builder/scan.cpp
@@ -99,7 +99,8 @@ Config Scan::go()
 
         m_files.save(ep, "", m_in, true);
         Json::Value json(out.json());
-        json.removeMember("input");
+        Json::Value removed;
+        json.removeMember("input",&removed);
         ep.put("scan.json", toPreciseString(json, true));
 
         if (m_in.verbose())

--- a/entwine/util/executor.cpp
+++ b/entwine/util/executor.cpp
@@ -131,11 +131,12 @@ std::unique_ptr<ScanInfo> Executor::preview(
         // in our metadata.  We still want any other options though - they may
         // be necessary for a proper preview - for example CSV or GDAL column
         // mappings.
+        Json::Value removed;
         if (readerJson.isObject())
         {
-            readerJson.removeMember("override_srs");
-            readerJson.removeMember("default_srs");
-            readerJson.removeMember("spatialreference");
+            readerJson.removeMember("override_srs",&removed);
+            readerJson.removeMember("default_srs",&removed);
+            readerJson.removeMember("spatialreference",&removed);
         }
 
         pdal::PipelineManager pm;


### PR DESCRIPTION
It seems that newer versions of `jsoncpp` require the `value` parameter to be passed when calling the `removeValue` method. I compiled entwine with `jsoncpp` version 1.8.4 on mac and the changes proposed in this PR fix the issue. I would think that this change is actually compatible with older versions of `jsonccp` as well. 