### PR TITLE
Made Google auth optional

### DIFF
--- a/entwine/third/arbiter/arbiter.cpp
+++ b/entwine/third/arbiter/arbiter.cpp
@@ -2677,7 +2677,15 @@ std::unique_ptr<Google::Auth> Google::Auth::create(const Json::Value& json)
     {
         if (const auto file = drivers::Fs().tryGet(*path))
         {
-            return util::makeUnique<Auth>(util::parse(*file));
+            try
+            {
+                return util::makeUnique<Auth>(util::parse(*file));
+            }
+            catch (const ArbiterError &e)
+            {
+                std::cout<< e.what() << std::endl;
+                return std::unique_ptr<Auth>();
+            }
         }
     }
     else if (json.isString())
@@ -2748,7 +2756,8 @@ void Google::Auth::maybeRefresh() const
     drivers::Https https(pool);
     const auto res(https.internalPost(tokenRequestUrl, body, headers));
 
-    if (!res.ok()) throw ArbiterError("Failed to get token: " + res.str());
+    if (!res.ok()) throw ArbiterError("Failed to get token for Google authentication"
+                                      ", request came back with response: " + res.str());
 
     const Json::Value token(util::parse(res.str()));
     m_headers["Authorization"] = "Bearer " + token["access_token"].asString();


### PR DESCRIPTION
When the environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set `entwine` tries to connect automatically to the referenced account (even if the program is running on a local file). If authentication fails the program was throwing an exception which I believe should be caught so that the code still runs when entwine is called on local files. Another option would be to authenticate only when the files are in some remote place (as opposed to authenticate by default). 

@connormanning what do you think about this? (I ran into this issue because of the time issue we discussed on the arbiter).