### PR TITLE
Fix potential out-of-bounds memory access when reading large files

### DIFF
--- a/entwine/builder/registry.cpp
+++ b/entwine/builder/registry.cpp
@@ -55,7 +55,7 @@ void Registry::merge(const Registry& other, Clipper& clipper)
 
         if (dxyz.d < m_metadata.sharedDepth())
         {
-            VectorPointTable table(m_metadata.schema());
+            VectorPointTable table(m_metadata.schema(), np);
             table.setProcess([this, &table, &clipper, &dxyz]()
             {
                 Voxel voxel;

--- a/entwine/io/binary.cpp
+++ b/entwine/io/binary.cpp
@@ -91,7 +91,7 @@ void Binary::read(
             m_metadata.outSchema(),
             std::move(*ensureGet(out, filename + ".bin")));
     const uint64_t np(src.capacity());
-    assert(np == src.capacity());
+    assert(np <= dst.capacity());
 
     // For reading, our destination schema will always be normalized (i.e. XYZ
     // as doubles).  So we can just copy the full dimension list and then


### PR DESCRIPTION
While trying to read large input files with more than 4096 entries, I noticed some out-of-bounds memory writes. This seems to be caused by pdal::StreamPointTable::clear not checking that the point count `np <= capacity`. As a fix I increased the the initial table size (and also made fixed the redundant assert check in `entwine::Binary::read`).