### PR TITLE
Adds description what the expected ordering is to `entwine build --bounds`

### DIFF
--- a/app/build.cpp
+++ b/app/build.cpp
@@ -96,7 +96,7 @@ void Build::addArgs()
     m_ap.add(
             "--bounds",
             "-b",
-            "XYZ bounds specification beyond which points will be discarded\n"
+            "XYZ bounds specification beyond which points will be discarded. Format is [xmin, ymin, zmin, xmax, ymax, zmax]\n"
             "Example: --bounds 0 0 0 100 100 100, -b \"[0,0,0,100,100,100]\"",
             [this](json j)
             {


### PR DESCRIPTION
I had to look up if I got the ordering right in the docs, I suggest putting this here so you can quickly reference it. 
```    
--bounds, -b
        XYZ bounds specification beyond which points will be discarded. Format is
        [xmin, ymin, zmin, xmax, ymax, zmax]

        Example: --bounds 0 0 0 100 100 100, -b "[0,0,0,100,100,100]"
```