### PR TITLE
Cesium tile bounds are now correctly calculated

### DIFF
--- a/entwine/formats/cesium/tile.hpp
+++ b/entwine/formats/cesium/tile.hpp
@@ -41,10 +41,10 @@ private:
     json toBox(Bounds in) const
     {
         return json {
-            in.mid()[0],    in.mid()[1],    in.mid()[2],
-            in.width(),     0,              0,
-            0,              in.depth(),     0,
-            0,              0,              in.height()
+            in.mid()[0],          in.mid()[1],          in.mid()[2],
+            in.width() / 2.0,     0,                    0,
+            0,                    in.depth() / 2.0,     0,
+            0,                    0,                    in.height() / 2.0
         };
     }
 

--- a/entwine/reader/chunk-reader.hpp
+++ b/entwine/reader/chunk-reader.hpp
@@ -29,7 +29,7 @@ public:
     VectorPointTable& table() { return *m_table; }
     std::size_t bytes() const
     {
-        return m_table->capacity() + m_table->pointSize();
+        return m_table->capacity() * m_table->pointSize();
     }
 
 private:


### PR DESCRIPTION
Cesium tile bounds are now correctly calculated as the half-size of the bounding box.

Fixes #168