### PR TITLE
Added ability to specify link_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ include(FeatureSummary)
 
 set(ROOT_DIR ${PROJECT_SOURCE_DIR})
 set(CMAKE_DIR ${ROOT_DIR}/cmake)
+link_directories(${ADDITIONAL_LINK_DIRECTORIES_PATHS})
 
 set(entwine_defs_hpp_in
     "${ROOT_DIR}/entwine/types/defs.hpp.in")


### PR DESCRIPTION
Hello :hand:

While trying to build entwine (using PDAL built from sources as well) I keep getting the following error message:

```
[ 94%] Building CXX object app/CMakeFiles/app.dir/entwine.cpp.o
[ 97%] Building CXX object app/CMakeFiles/app.dir/scan.cpp.o
[100%] Linking CXX executable entwine
/usr/bin/ld: cannot find -lpdalcpp
collect2: error: ld returned 1 exit status
```

I should mention that we place the pdal libraries in a non-conventional location (neither /usr/lib or /usr/local/lib) as part of the build process. This is the cmake command we're using:

```
cmake     -DCMAKE_CXX_FLAGS=-isystem\ /ourbuildpath/sources/pdal
    -DWITH_TESTS=OFF
    -DCMAKE_BUILD_TYPE=Release
    -DCMAKE_INSTALL_PREFIX:PATH=/ourbuildpath/install
```

The `/ourbuildpath/install/lib` is where the `libpdalcpp.so` file is located.

I've got entwine to compile by adding to the cmake command (plus the changes in this PR):

```
`cmake     -DCMAKE_CXX_FLAGS=-isystem\ /ourbuildpath/sources/pdal
    -DADDITIONAL_LINK_DIRECTORIES_PATHS=/ourbuildpath/install/lib
    -DWITH_TESTS=OFF
    -DCMAKE_BUILD_TYPE=Release
    -DCMAKE_INSTALL_PREFIX:PATH=/ourbuildpath/install`
```

I'm not a huge expert with cmake and perhaps there's a better way to do this?

Thanks!