### PR TITLE
Added support for --tmp in merge

### DIFF
--- a/app/merge.cpp
+++ b/app/merge.cpp
@@ -29,6 +29,7 @@ void Merge::addArgs()
 
     addOutput("Path containing completed subset builds", true);
     addConfig();
+    addTmp();
     addSimpleThreads();
     addArbiter();
 }


### PR DESCRIPTION
Hello :hand:

Just noticed that the docs specify that the merge commands support specifying the `tmp` directory https://entwine.io/configuration.html#merge (from the command line via `--tmp`) but that's currently not supported.

I think it's just a matter of adding `addTmp()`.