### PR TITLE
Fixing bug in case vlrs are not present

### DIFF
--- a/entwine/builder/scan.cpp
+++ b/entwine/builder/scan.cpp
@@ -210,10 +210,14 @@ void Scan::addLas(FileInfo& f)
     header = headerStream.str();
     std::vector<char> data(header.data(), header.data() + headerSize);
 
-    const auto vlrs = m_arbiter.getBinary(
-            f.path(),
-            rangeHeaders(headerSize, pointOffset));
-    data.insert(data.end(), vlrs.begin(), vlrs.end());
+    // check if has vlrs
+    bool hasVlrcs = headerSize < pointOffset;
+    if (hasVlrcs)
+    {
+        const auto vlrs = m_arbiter.getBinary(
+            f.path(), rangeHeaders(headerSize, pointOffset));
+        data.insert(data.end(), vlrs.begin(), vlrs.end());
+    }
 
     if (minorVersion >= 4)
     {


### PR DESCRIPTION
When vlrs are not present in an las file, then the `rangeHeaders` are `headerSize-(headerSize-1)` which is not a valid range request it appears. I am not sure what exactly happens but I suspects that it downloads the whole file which is not ideal. I added a chec k to grab those extra headers only if they are present