### PR TITLE
Fixing bug in case evlr offset is missing

### DIFF
--- a/entwine/builder/scan.cpp
+++ b/entwine/builder/scan.cpp
@@ -246,7 +246,7 @@ void Scan::addLas(FileInfo& f)
         data.insert(data.end(), vlrs.begin(), vlrs.end());
     }
 
-    if (evlrNumber)
+    if (evlrNumber && evlrOffset)
     {
         const auto evlrs = m_arbiter.getBinary(
                 f.path(),


### PR DESCRIPTION
evlr offset is currently missing from laz files written by PDAL. This PR ensures that they are ignored if missing.