### PR TITLE
Ignore SIGPIPE signals to prevent crashing when writing to a broken socket

### DIFF
--- a/app/entwine.cpp
+++ b/app/entwine.cpp
@@ -287,6 +287,9 @@ int main(int argc, char** argv)
     signal(SIGINT, [](int sig) { exit(1); });
     entwine::stackTraceOn(SIGSEGV);
 
+    // We ignore SIGPIPE to prevent crashing in some cases
+    signal(SIGPIPE, SIG_IGN);
+
     if (argc < 2)
     {
         std::cout << "App type required\n" << getUsageString() << std::endl;


### PR DESCRIPTION
We've noticed that when running builds commands on a GCS output sometimes TLS connections will fail, and the next write will cause a SIGPIPE. Curl is configured to not handle any signals, causing entwine to crash. We applied this patch to prevent crashing, but I'm not sure if this is the best way to handle it.