### PR TITLE
use GITHUB_PATH env variable for adding paths

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Paths
       shell: bash -l {0}
       run: |
-          echo "::add-path::D:/a/entwine/entwine/build/bin"
+          echo "D:/a/entwine/entwine/build/bin" >> $GITHUB_PATH
 
     - name: Test
       shell: bash -l {0}


### PR DESCRIPTION
Github changed environment variable policies, so we need to adapt. 

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files