### PR TITLE
OpenSSL is required

### DIFF
--- a/cmake/openssl.cmake
+++ b/cmake/openssl.cmake
@@ -1,4 +1,4 @@
-find_package(OpenSSL 1.0.1)
+find_package(OpenSSL 1.0.1 REQUIRED)
 if (OPENSSL_FOUND)
     set(ARBITER_OPENSSL TRUE)
     set(ENTWINE_OPENSSL TRUE)


### PR DESCRIPTION
Without this line, configuration will succeed but build files will not be able to be generated. Better to abort earlier I think.