### PR TITLE
Include PDAL's las header

### DIFF
--- a/entwine/util/pipeline.cpp
+++ b/entwine/util/pipeline.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 
 #include <pdal/io/LasReader.hpp>
+#include <pdal/io/LasHeader.hpp>
 
 namespace entwine
 {


### PR DESCRIPTION
When building against PDAL 2.2.0, this line is required because of a forward declaration of LasHeader in LasReader.