### PR TITLE
Allow entwine builds without zstd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ set(entwine_defs_hpp
     ${PROJECT_BINARY_DIR}/include/entwine/types/defs.hpp)
 configure_file(${entwine_defs_hpp_in} ${entwine_defs_hpp})
 
+option(WITH_ZSTD
+    "Build support for compression/decompression with Zstd." TRUE)
+if (NOT WITH_ZSTD)
+    add_definitions(-DNO_ZSTD)
+endif()
+
 include(${CMAKE_DIR}/threads.cmake)
 include(${CMAKE_DIR}/backtrace.cmake)
 include(${CMAKE_DIR}/curl.cmake)

--- a/entwine/io/zstandard.cpp
+++ b/entwine/io/zstandard.cpp
@@ -9,8 +9,9 @@
 ******************************************************************************/
 
 #include <entwine/io/zstandard.hpp>
-
+#ifndef NO_ZSTD
 #include <pdal/compression/ZstdCompression.hpp>
+#endif
 #include <pdal/filters/SortFilter.hpp>
 
 #include <entwine/util/io.hpp>
@@ -29,6 +30,7 @@ void write(
     BlockPointTable& table,
     const Bounds bounds)
 {
+#ifndef NO_ZSTD
     const std::vector<char> uncompressed = binary::pack(metadata, table);
 
     std::vector<char> compressed;
@@ -41,6 +43,9 @@ void write(
     compressor.done();
 
     ensurePut(endpoints.data, filename + ".zst", compressed);
+#else
+    throw std::runtime_error("Entwine was not built with zstd support.");
+#endif
 }
 
 void read(
@@ -49,6 +54,7 @@ void read(
     const std::string filename,
     VectorPointTable& table)
 {
+#ifndef NO_ZSTD
     const std::vector<char> compressed = ensureGetBinary(
         endpoints.data,
         filename + ".zst");
@@ -62,6 +68,9 @@ void read(
     dec.decompress(compressed.data(), compressed.size());
 
     binary::unpack(metadata, table, std::move(uncompressed));
+#else
+    throw std::runtime_error("Entwine was not built with zstd support.");
+#endif
 }
 
 } // namespace zstandard


### PR DESCRIPTION
Hello :hand:

Since PDAL can be built without ZSTD﻿, I thought to add a PR that allows entwine to be built without ZSTD support also.

This can be handy if one doesn't care to have zstd compression.

Let me know if changes are needed :pray: ?
