### PR TITLE
uppercase CURL to address CMake dev warnings

### DIFF
--- a/cmake/curl.cmake
+++ b/cmake/curl.cmake
@@ -1,4 +1,4 @@
-find_package(Curl)
+find_package(CURL)
 if (CURL_FOUND)
     set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
     find_package(Threads REQUIRED)


### PR DESCRIPTION
Currently, when compiling CMake warns about the spelling of `Curl`. Looking at the CI logs, this is consistent across all platforms. This PR uppercases to CURL which removes the warning (tested locally).

```
-- Found Threads: TRUE  
CMake Warning (dev) at C:/Miniconda/envs/test/Library/share/cmake-3.20/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (CURL) does
-- Found CURL: C:/Miniconda/envs/test/Library/lib/libcurl.lib (found version "7.77.0") 
  not match the name of the calling package (Curl).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/modules/FindCurl.cmake:61 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  cmake/curl.cmake:1 (find_package)
  CMakeLists.txt:45 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

```