### PR TITLE
Changed exception handler from std::runtime_error to std::exception.

### DIFF
--- a/app/entwine.cpp
+++ b/app/entwine.cpp
@@ -422,11 +422,16 @@ int main(int argc, char** argv)
             std::cout << getUsageString() << std::endl;
         }
     }
-    catch (std::runtime_error& e)
+    catch (std::exception& e)
     {
         std::cout << "Encountered an error: " << e.what() << std::endl;
         std::cout << "Exiting." << std::endl;
         return 1;
+    }
+    catch (...)
+    {
+        std::cout << "Encountered an unknown exception!"  << std::endl;
+        return 2;
     }
 
     return 0;


### PR DESCRIPTION
I added an exception handler for the base class of std::exception: this will future proof all other std::exception derived exceptions.  It also fixes the problem with JSON parsing errors crashing entwine.

I also added the catch all, in case some future library doesn't derive from std::exception, with the thinking that It is far better to write something out on stdout/stderr than just crash.  See https://github.com/connormanning/entwine/issues/264