### PR TITLE
Fix building against recent (main branch) of PDAL.

### DIFF
--- a/entwine/util/pipeline.cpp
+++ b/entwine/util/pipeline.cpp
@@ -120,8 +120,8 @@ optional<ScaleOffset> getScaleOffset(const pdal::Reader& reader)
     {
         const auto& h(las->header());
         return ScaleOffset(
-            Scale(h.scaleX(), h.scaleY(), h.scaleZ()),
-            Offset(h.offsetX(), h.offsetY(), h.offsetZ())
+            Scale(h.scale.x, h.scale.y, h.scale.z),
+            Offset(h.offset.x, h.offset.y, h.offset.z)
         );
     }
     return { };


### PR DESCRIPTION
LasHeader was refactored in PDAL so that:

scaleX(), scaleY(), scaleZ(), offsetX(), offsetY(), offsetZ()

are now

scale.x, scale.y, scale.z, offset.x, offset.y, offset.z

as of PDAL/PDAL@dd00e3a7