### PR TITLE
fixes building against PDAL >v2.3.0

### DIFF
--- a/cmake/pdal.cmake
+++ b/cmake/pdal.cmake
@@ -1,3 +1,5 @@
+include(CheckCXXSymbolExists)
+
 find_package(PDAL 2.1.0 REQUIRED CONFIG NO_POLICY_SCOPE)
 
 get_target_property(PDALCPP_INCLUDE_DIRS pdalcpp INTERFACE_INCLUDE_DIRECTORIES)
@@ -7,3 +9,14 @@ if (PDALCPP_INCLUDE_DIRS)
 else()
 	set(LASZIP_DIRECTORIES /usr/include/laszip /usr/local/include/laszip)
 endif()
+
+# PDAL LAS API changes between 2.3.0 & 2.4 https://github.com/PDAL/PDAL/commit/dd00e3a7
+get_target_property(CMAKE_REQUIRED_INCLUDES pdalcpp INTERFACE_INCLUDE_DIRECTORIES)
+set(CMAKE_REQUIRED_LIBRARIES pdalcpp)
+set(CMAKE_REQUIRED_FLAGS "-std=c++${CMAKE_CXX_STANDARD}")
+
+check_cxx_symbol_exists("pdal::las::baseCount" "pdal/io/LasHeader.hpp" PDAL_HAS_LAS_REFACTOR)
+
+unset(CMAKE_REQUIRED_FLAGS)
+unset(CMAKE_REQUIRED_LIBRARIES)
+unset(CMAKE_REQUIRED_INCLUDES)

--- a/entwine/util/CMakeLists.txt
+++ b/entwine/util/CMakeLists.txt
@@ -33,3 +33,8 @@ set(
 install(FILES ${HEADERS} DESTINATION include/entwine/${MODULE})
 add_library(${MODULE} OBJECT ${SOURCES})
 compiler_options(${MODULE})
+
+if(PDAL_HAS_LAS_REFACTOR)
+    # PDAL LAS API changes between 2.3.0 & 2.4 https://github.com/PDAL/PDAL/commit/dd00e3a7
+    add_compile_definitions(PDAL_HAS_LAS_REFACTOR)
+endif()

--- a/entwine/util/pipeline.cpp
+++ b/entwine/util/pipeline.cpp
@@ -119,10 +119,19 @@ optional<ScaleOffset> getScaleOffset(const pdal::Reader& reader)
     if (const auto* las = dynamic_cast<const pdal::LasReader*>(&reader))
     {
         const auto& h(las->header());
+
+// PDAL LAS API changes between 2.3.0 and 2.4: https://github.com/PDAL/PDAL/commit/dd00e3a7
+#ifdef PDAL_HAS_LAS_REFACTOR
+        return ScaleOffset(
+            Scale(h.scale.x, h.scale.y, h.scale.z),
+            Offset(h.offset.x, h.offset.y, h.offset.z)
+        );
+#else
         return ScaleOffset(
             Scale(h.scaleX(), h.scaleY(), h.scaleZ()),
             Offset(h.offsetX(), h.offsetY(), h.offsetZ())
         );
+#endif
     }
     return { };
 }


### PR DESCRIPTION
This is an expansion of https://github.com/connormanning/entwine/pull/275 to add configure-time detection of the new API to cmake for both forward and backward compatibility with the PDAL LAS refactoring from https://github.com/PDAL/PDAL/commit/dd00e3a7. Tested with 2.3.0 and main@3b2942b

Related: https://github.com/PDAL/PDAL/issues/3677

/cc @abellgithub 