### PR TITLE
fix cmake issue #282: Backtrace is optional, skip linking if not present

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -20,12 +20,15 @@ target_link_libraries(app
     PRIVATE
         entwine
         ${PDAL_LIBRARIES}
-        ${Backtrace_LIBRARIES}
         ${CMAKE_DL_LIBS}
         ${CMAKE_THREAD_LIBS_INIT}
         ${JSONCPP_LIBRARY}
 )
+
+if (DEFINED BACKTRACE_DEFS)
+  target_link_libraries(app PRIVATE ${Backtrace_LIBRARIES})
+endif (DEFINED BACKTRACE_DEFS)
+
 set_target_properties(app PROPERTIES OUTPUT_NAME entwine)
 
 install(TARGETS app DESTINATION bin)
-


### PR DESCRIPTION
this is a possible fix for #282