### PR TITLE
`resolve()`: pattern-match paths matching a postfix

### DIFF
--- a/entwine/util/fs.cpp
+++ b/entwine/util/fs.cpp
@@ -52,7 +52,7 @@ StringList resolve(const StringList& input, const arbiter::Arbiter& a)
                 }
                 if (last != '/') item.push_back('/');
                 item.push_back('*');
-			}
+            }
             const StringList directory(a.resolve(item));
             for (const auto& item : directory)
             {

--- a/entwine/util/fs.cpp
+++ b/entwine/util/fs.cpp
@@ -10,6 +10,8 @@
 
 #include <entwine/util/fs.hpp>
 
+#include <pdal/util/Utils.hpp>
+
 #include <stdexcept>
 
 namespace entwine
@@ -33,18 +35,28 @@ StringList resolve(const StringList& input, const arbiter::Arbiter& a)
     StringList output;
     for (std::string item : input)
     {
-        if (isDirectory(item))
+        if (isDirectory(item) || (item.find('*') != std::string::npos))
         {
+            // arbiter::resolve() globs for * or ** only if they are at the end of
+            // a path. To resolve these , we need to split the string
+            // so it ends in *, then filter the results later.
+            std::string postfix;
             const char last = item.back();
             if (last != '*')
             {
+                auto pos = item.find_last_of('*');
+                if (pos != std::string::npos)
+                {
+                    postfix = item.substr(pos + 1);
+                    item = item.substr(0, pos);
+                }
                 if (last != '/') item.push_back('/');
                 item.push_back('*');
-            }
-
+			}
             const StringList directory(a.resolve(item));
             for (const auto& item : directory)
             {
+                if (postfix.size() && !pdal::Utils::endsWith(item, postfix)) continue;
                 if (!isDirectory(item)) output.push_back(item);
             }
         }

--- a/test/unit/info.cpp
+++ b/test/unit/info.cpp
@@ -84,6 +84,12 @@ TEST(info, directory)
 
     EXPECT_EQ(list.size(), 9);
 
+    // Testing that it can resolve postfix after a wildcard:
+    const StringList globInputs{test::dataPath() + "ellipsoid-multi/*u.laz"};
+    const auto globList = analyze(globInputs);
+
+    EXPECT_EQ(globList.size(), 4);
+     
     const auto info = manifest::reduce(list);
 
     EXPECT_EQ(info.errors.size(), 1);


### PR DESCRIPTION
Closes #334. Changed `resolve()` to filter Arbiter's glob results for patterns specifying a specific file ending, eg. `s3://somebucket/someprefix/*.laz`. 