### PR TITLE
Fix build

### DIFF
--- a/scripts/ci/environment.yml
+++ b/scripts/ci/environment.yml
@@ -2,7 +2,7 @@ name: entwine-build
 channels:
   - conda-forge
 dependencies:
-  - libpdal-core
+  - libpdal-core!=2.9.0
   - compilers
   - conda-build
   - ninja


### PR DESCRIPTION
`master` does not currently build on github. This is because PDAL 2.9.0 is being used, and entwine does not build properly with PDAL 2.9.0. This PR makes sure PDAL 2.9.0 is not used.

Maybe pinning all dependencies to known working versions would be useful?

Here's a run showing the failure: https://github.com/NathanMOlson/entwine/actions/runs/17087795632