### PR TITLE
Fix S3 glob XML parsing to ignore non-Contents nodes (e.g. Marker)

### DIFF
--- a/entwine/third/arbiter/arbiter.cpp
+++ b/entwine/third/arbiter/arbiter.cpp
@@ -2426,7 +2426,7 @@ std::vector<std::string> S3::glob(std::string path, bool verbose) const
 
             if (XmlNode* conNode = topNode->first_node("Contents"))
             {
-                for ( ; conNode; conNode = conNode->next_sibling())
+                for ( ; conNode; conNode = conNode->next_sibling("Contents"))
                 {
                     if (XmlNode* keyNode = conNode->first_node("Key"))
                     {


### PR DESCRIPTION
## Summary

This PR fixes a bug in `S3::glob` where the XML parsing loop incorrectly assumes that all sibling nodes following the first `<Contents>` node are also `<Contents>` nodes.

## The Issue

When using S3-compatible storage providers (specifically **Digital Ocean Spaces** in my case), the `ListBucketResult` XML response may contain additional nodes like `<Marker>` appearing after the last `<Contents>` node.

The current implementation uses `conNode = conNode->next_sibling()` without arguments. This causes the loop to iterate over these non-`Contents` nodes. Since `<Marker>` (and probably others) do not contain a `<Key>` child, the function throws an `ArbiterError("Missing Key...")`.

Example of crashing XML response:

```XML
<ListBucketResult ...>
    ...
    <Contents>
        <Key>path/to/file.laz</Key>
        ...
    </Contents>
    <Marker></Marker>
</ListBucketResult>
```

## The Fix

I updated the loop to explicitly request the next sibling _with_ the name "Contents":

```C++
// Before
for ( ; conNode; conNode = conNode->next_sibling())

// After
for ( ; conNode; conNode = conNode->next_sibling("Contents"))
```

This ensures that `RapidXML` skips any sibling nodes that are not `<Contents>`, preventing the crash on valid S3 responses that include metadata like markers at the end of the list.