### PR TITLE
Fix Io metadata reference after Builder move

### DIFF
--- a/entwine/builder/builder.cpp
+++ b/entwine/builder/builder.cpp
@@ -58,6 +58,29 @@ Builder::Builder(
     , verbose(verbose)
 { }
 
+Builder::Builder(Builder&& o) noexcept
+    : endpoints(std::move(o.endpoints))
+    , metadata(std::move(o.metadata))
+    , io(Io::create(metadata, endpoints))
+    , manifest(std::move(o.manifest))
+    , hierarchy(std::move(o.hierarchy))
+    , verbose(o.verbose)
+{ }
+
+Builder& Builder::operator=(Builder&& o) noexcept
+{
+    if (this != &o)
+    {
+        endpoints = std::move(o.endpoints);
+        metadata = std::move(o.metadata);
+        manifest = std::move(o.manifest);
+        hierarchy = std::move(o.hierarchy);
+        verbose = o.verbose;
+        io = Io::create(metadata, endpoints);
+    }
+    return *this;
+}
+
 uint64_t Builder::run(
     const Threads threads,
     const uint64_t limit,

--- a/entwine/builder/builder.hpp
+++ b/entwine/builder/builder.hpp
@@ -33,6 +33,9 @@ struct Builder
         Hierarchy hierarchy = Hierarchy(),
         bool verbose = true);
 
+    Builder(Builder&&) noexcept;
+    Builder& operator=(Builder&&) noexcept;
+
     uint64_t run(
         Threads threads,
         uint64_t limit = 0,

--- a/test/unit/build.cpp
+++ b/test/unit/build.cpp
@@ -167,6 +167,28 @@ TEST(build, failedWrite)
     ASSERT_ANY_THROW(builder::run(builder, config));
 }
 
+TEST(build, movedBuilderIoMetadata)
+{
+    const json config = {
+        { "input", test::dataPath() + "ellipsoid.laz" },
+        { "output", outDir },
+        { "force", true },
+        { "verbose", false },
+        { "progressInterval", 0 },
+        { "span", 32 },
+        { "hierarchyStep", 2 }
+    };
+    Builder builder = builder::create(config);
+    ASSERT_TRUE(contains(builder.metadata.schema, "X"));
+
+    Builder moved(std::move(builder));
+    EXPECT_EQ(&moved.io->metadata, &moved.metadata);
+    EXPECT_TRUE(contains(moved.io->metadata.schema, "X"));
+
+    const uint64_t count = builder::run(moved, config);
+    EXPECT_GT(count, 0u);
+}
+
 TEST(build, binary)
 {
     run({


### PR DESCRIPTION
## Summary

- Fix dangling `Metadata&` / `Endpoints&` in `Io` after `Builder` is move-constructed or move-assigned.
- `Laszip` (and other `Io` implementations) capture references at construction; the compiler-generated move moved `unique_ptr<Io>` but left those references pointing at the moved-from `Builder` metadata (empty schema), causing chunk serialization to fail with `Failed to find dimension: X`.
- Recreate `io` via `Io::create(metadata, endpoints)` in the move constructor and move assignment operator.
- Add `build.movedBuilderIoMetadata` unit test: after `std::move`, `io->metadata` must alias `moved.metadata` and a full build still writes tiles.

## Context

The CLI path `Builder builder = builder::create(config)` uses guaranteed copy elision and does not hit this bug. Embedding code that move-constructs `Builder` (e.g. `std::make_shared<Builder>(builder::create(config))`) does.

## Test plan

- [x] `build.movedBuilderIoMetadata` — move alias + end-to-end build on ellipsoid.laz
- [ ] CI unit tests (`test/unit/build.cpp`)